### PR TITLE
refactor: Simplify all shell scripts for better maintainability

### DIFF
--- a/scripts/mcdl.sh
+++ b/scripts/mcdl.sh
@@ -1,57 +1,30 @@
 #!/usr/bin/env bash
+# mcdl.sh: Simple Fabric server downloader
 
-# Source common functions (SCRIPT_DIR is auto-initialized)
 source "$(dirname -- "${BASH_SOURCE[0]}")/../lib/common.sh"
 
 init_strict_mode
 
-# ── Configurable environment vars ─────────────────────
-# MC_VERSION    : override to pin a Minecraft version (e.g. "1.21.6")
-# LOADER        : override to pin a Fabric Loader version (e.g. "0.16.14")
-# STABLE_LOADER : "true" (default) to pick newest stable loader; "false" for absolute newest
-
 # Get JSON processor
 JSON_PROC=$(get_json_processor) || exit 1
 
-# Cache API responses to avoid redundant network calls
-print_header "Fetching Minecraft and Fabric versions..."
-GAME_VERSIONS=$(fetch_url "https://meta.fabricmc.net/v2/versions/game") || exit 1
-MC_VERSION="${MC_VERSION:-$(echo "$GAME_VERSIONS" | "$JSON_PROC" -r '.[] | select(.stable == true) | .version' | head -n1)}"
-FABRIC_VERSION=$(fetch_url "https://meta.fabricmc.net/v2/versions/installer" | "$JSON_PROC" -r '.[0].version') || exit 1
+# Fetch versions
+print_info "Fetching Minecraft and Fabric versions..."
+MC_VERSION="${MC_VERSION:-$(fetch_url "https://meta.fabricmc.net/v2/versions/game" | "$JSON_PROC" -r '[.[] | select(.stable == true)][0].version')}"
+FABRIC_VERSION=$(fetch_url "https://meta.fabricmc.net/v2/versions/installer" | "$JSON_PROC" -r '.[0].version')
+LOADER="${LOADER:-$(fetch_url "https://meta.fabricmc.net/v2/versions/loader" | "$JSON_PROC" -r '[.[] | select(.stable==true)][0].version')}"
 
-print_info "Minecraft version: $MC_VERSION"
-print_info "Fabric installer version: $FABRIC_VERSION"
+print_info "Minecraft: $MC_VERSION | Fabric installer: $FABRIC_VERSION | Loader: $LOADER"
 
 # Download and run Fabric installer
-print_header "Downloading Fabric installer..."
-download_file "https://maven.fabricmc.net/net/fabricmc/fabric-installer/${FABRIC_VERSION}/fabric-installer-${FABRIC_VERSION}.jar" "fabric-installer.jar" || exit 1
-print_success "Fabric installer downloaded"
+print_info "Downloading Fabric installer..."
+download_file "https://maven.fabricmc.net/net/fabricmc/fabric-installer/${FABRIC_VERSION}/fabric-installer-${FABRIC_VERSION}.jar" \
+    "fabric-installer.jar"
 
-print_header "Installing Fabric server..."
+print_info "Installing Fabric server..."
 java -jar fabric-installer.jar server -mcversion "$MC_VERSION" -downloadMinecraft
-print_success "Fabric server installed"
 
-# Resolve Loader version
-print_header "Resolving Fabric Loader version..."
-LOADER_VERSIONS=$(fetch_url "https://meta.fabricmc.net/v2/versions/loader") || exit 1
-if [[ ${STABLE_LOADER:-true} = true ]]; then
-    LOADER="${LOADER:-$(echo "$LOADER_VERSIONS" | "$JSON_PROC" -r '.[] | select(.stable==true) | .version' | head -n1)}"
-else
-    LOADER="${LOADER:-$(echo "$LOADER_VERSIONS" | "$JSON_PROC" -r '.[0].version')}"
-fi
-
-# Lookup matching intermediary (mappings) version
-INTERMEDIARY="$(
-    fetch_url "https://meta.fabricmc.net/v2/versions/loader/${MC_VERSION}/${LOADER}" \
-        | "$JSON_PROC" -r '.[0].intermediary'
-)" || exit 1
-
-print_info "Fabric Loader: $LOADER (stable filter: ${STABLE_LOADER:-true})"
-print_info "Intermediary:  $INTERMEDIARY"
-
-# Download the server-loader jar
-print_header "Downloading server-loader jar..."
-download_file "https://meta.fabricmc.net/v2/versions/loader/${MC_VERSION}/${LOADER}/${INTERMEDIARY}/server/jar" \
-  "fabric-server-mc.${MC_VERSION}-loader.${LOADER}-launcher.${INTERMEDIARY}.jar" || exit 1
+# Cleanup installer
+rm -f fabric-installer.jar
 
 print_success "Fabric server setup complete!"

--- a/scripts/mod-updates.sh
+++ b/scripts/mod-updates.sh
@@ -1,50 +1,30 @@
 #!/usr/bin/env bash
-# mod-updates.sh: Unified Minecraft mod manager and update system
+# mod-updates.sh: Simplified mod update system
 
-# Source common functions (SCRIPT_DIR is auto-initialized)
 source "$(dirname -- "${BASH_SOURCE[0]}")/../lib/common.sh"
 
 init_strict_mode
 
-# ─── Configuration ──────────────────────────────────────────────────────────────
-
-CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/mod-manager"
-PROFILES_DIR="$CONFIG_DIR/profiles"
-CURRENT_PROFILE="$CONFIG_DIR/current_profile"
+# Configuration
 MC_REPACK_CONFIG="${HOME}/.config/mc-repack.toml"
 
 # Get JSON processor
 JSON_PROC=$(get_json_processor) || exit 1
 
-# Ensure config directories exist
-ensure_dir "$CONFIG_DIR"
-ensure_dir "$PROFILES_DIR"
-
-# ─── System Setup ───────────────────────────────────────────────────────────────
-
-setup_server(){
-    print_header "Setting up Minecraft server environment"
-    # Accept EULA
+# Setup server environment
+setup_server() {
+    print_header "Setting up server environment"
     echo "eula=true" > eula.txt
-    print_success "EULA accepted"
-    # Fix ownership and permissions
-    if [[ -d world ]]; then
-        print_info "Fixing ownership of server files..."
-        sudo chown -R "$(id -un):$(id -gn)" world 2>/dev/null || :
-    fi
+    [[ -d world ]] && sudo chown -R "$(id -un):$(id -gn)" world 2>/dev/null || :
     sudo chmod -R 755 ./*.sh 2>/dev/null || :
-    print_success "Ownership and permissions fixed"
+    print_success "Server setup complete"
 }
 
-setup_mc_repack(){
+# Configure mc-repack
+setup_mc_repack() {
     print_header "Configuring mc-repack"
-    touch "$MC_REPACK_CONFIG"
-    # Remove old TOML sections
-    if has_command sd; then
-        sd -s '^\[(json|nbt|png|toml|jar)\](\n(?!\[).*)*' '' "$MC_REPACK_CONFIG" 2>/dev/null || :
-    fi
-    # Append optimized configuration
-    cat >> "$MC_REPACK_CONFIG" <<'EOF'
+    mkdir -p "$(dirname "$MC_REPACK_CONFIG")"
+    cat > "$MC_REPACK_CONFIG" <<'EOF'
 [json]
 remove_underscored = true
 [nbt]
@@ -57,355 +37,109 @@ strip_strings = true
 keep_dirs = false
 use_zopfli = true
 EOF
-    print_success "mc-repack.toml configured"
+    print_success "mc-repack configured"
 }
 
-# ─── Profile Management ─────────────────────────────────────────────────────────
-
-create_profile(){
-    local name="$1" mc_version="$2" mod_loader="$3" output_dir="$4"
-    if [[ -z "$name" ]] || [[ -z "$mc_version" ]] || [[ -z "$mod_loader" ]] || [[ -z "$output_dir" ]]; then
-        print_error "Usage: $0 profile create <name> <mc_version> <mod_loader> <output_dir>"
-        print_info "Example: $0 profile create my-mods 1.21.6 fabric ./mods"; return 1
-    fi
-    local profile_file="$PROFILES_DIR/$name.json"
-    [[ -f "$profile_file" ]] && { print_error "Profile '$name' already exists"; return 1; }
-    cat > "$profile_file" <<EOF
-{
-  "name": "$name",
-  "mc_version": "$mc_version",
-  "mod_loader": "$mod_loader",
-  "output_dir": "$output_dir",
-  "mods": []
-}
-EOF
-    echo "$name" > "$CURRENT_PROFILE"
-    print_success "Created profile '$name'"
-    print_info "Minecraft: $mc_version | Loader: $mod_loader | Output: $output_dir"
-}
-
-list_profiles(){
-    local current=""
-    [[ -f "$CURRENT_PROFILE" ]] && current=$(cat "$CURRENT_PROFILE")
-    print_header "Available Profiles:"
-    if [[ ! -d "$PROFILES_DIR" ]] || [[ -z "$(ls -A "$PROFILES_DIR" 2>/dev/null)" ]]; then
-        print_info "No profiles found. Create one with: $0 profile create"; return
-    fi
-    for profile in "$PROFILES_DIR"/*.json; do
-        [[ ! -f "$profile" ]] && continue
-        local name=$(basename "$profile" .json)
-        local mc_version=$($JSON_PROC -r '.mc_version' < "$profile")
-        local mod_loader=$($JSON_PROC -r '.mod_loader' < "$profile")
-        local mod_count=$($JSON_PROC -r '.mods | length' < "$profile")
-        if [[ "$name" == "$current" ]]; then
-            echo -e "${GREEN}* $name${NC} (MC $mc_version, $mod_loader, $mod_count mods)"
-        else
-            echo "  $name (MC $mc_version, $mod_loader, $mod_count mods)"
-        fi
-    done
-}
-
-switch_profile(){
-    local name="$1"
-    local profile_file="$PROFILES_DIR/$name.json"
-    if [[ ! -f "$profile_file" ]]; then
-        print_error "Profile '$name' not found"; return 1
-    fi
-    echo "$name" > "$CURRENT_PROFILE"
-    print_success "Switched to profile '$name'"
-}
-
-get_current_profile(){
-    if [[ ! -f "$CURRENT_PROFILE" ]]; then
-        print_error "No active profile. Create one with: $0 profile create"; return 1
-    fi
-    local name=$(cat "$CURRENT_PROFILE")
-    local profile_file="$PROFILES_DIR/$name.json"
-    if [[ ! -f "$profile_file" ]]; then
-        print_error "Current profile '$name' not found"; return 1
-    fi
-    echo "$profile_file"
-}
-
-# ─── Mod Operations ─────────────────────────────────────────────────────────────
-
-add_modrinth_mod(){
-    local slug="$1"
-    local profile_file=$(get_current_profile) || return 1
-    print_header "Adding Modrinth mod: $slug"
-    local project_info=$(fetch_url "https://api.modrinth.com/v2/project/$slug")
-    [[ -z "$project_info" ]] && { print_error "Failed to fetch mod info for '$slug'"; return 1; }
-    local project_id=$(echo "$project_info" | $JSON_PROC -r '.id')
-    local title=$(echo "$project_info" | $JSON_PROC -r '.title')
-    local exists=$($JSON_PROC -r --arg id "$project_id" '.mods[] | select(.id == $id) | .id' < "$profile_file")
-    [[ -n "$exists" ]] && { print_error "Mod '$title' is already in the profile"; return 1; }
-    local temp_file=$(mktemp)
-    $JSON_PROC \
-        --arg id "$project_id" \
-        --arg slug "$slug" \
-        --arg title "$title" \
-        '.mods += [{"source": "modrinth", "id": $id, "slug": $slug, "title": $title}]' \
-        < "$profile_file" > "$temp_file"
-
-    mv "$temp_file" "$profile_file"
-    print_success "Added '$title' to profile"
-}
-
-add_curseforge_mod(){
-    local project_id="$1"
-    local profile_file=$(get_current_profile) || return 1
-    print_header "Adding CurseForge mod: $project_id"
-    local exists=$($JSON_PROC -r --arg id "$project_id" '.mods[] | select(.id == $id) | .id' < "$profile_file")
-    [[ -n "$exists" ]] && { print_error "Mod with ID '$project_id' already in profile"; return 1; }
-    local temp_file=$(mktemp)
-    $JSON_PROC \
-        --arg id "$project_id" \
-        '.mods += [{"source": "curseforge", "id": $id, "title": "CurseForge Mod " + $id}]' \
-        < "$profile_file" > "$temp_file"
-    mv "$temp_file" "$profile_file"
-    print_success "Added CurseForge mod (ID: $project_id)"
-    print_info "Note: CurseForge downloads require an API key"
-}
-
-list_mods(){
-    local profile_file=$(get_current_profile) || return 1
-    local profile_name=$(basename "$profile_file" .json)
-    print_header "Mods in profile '$profile_name':"
-    local mod_count=$($JSON_PROC -r '.mods | length' < "$profile_file")
-    [[ $mod_count -eq 0 ]] && { print_info "No mods in profile. Add with: $0 add"; return; }
-    $JSON_PROC -r '.mods[] | "[\(.source)] \(.title) (\(.slug // .id))"' < "$profile_file" | \
-    while IFS= read -r line; do echo "  $line"; done
-}
-
-remove_mod(){
-    local identifier="$1"
-    local profile_file=$(get_current_profile) || return 1
-    [[ -z "$identifier" ]] && { print_error "Usage: $0 remove <slug|id>"; return 1; }
-    local removed=$($JSON_PROC -r --arg id "$identifier" \
-        '.mods[] | select(.slug == $id or .id == $id) | .title' < "$profile_file")
-    [[ -z "$removed" ]] && { print_error "Mod '$identifier' not found"; return 1; }
-    local temp_file=$(mktemp)
-    $JSON_PROC --arg id "$identifier" \
-        '.mods |= map(select(.slug != $id and .id != $id))' < "$profile_file" > "$temp_file"
-    mv "$temp_file" "$profile_file"
-    print_success "Removed '$removed'"
-}
-
-download_modrinth_mod(){
-    local project_id="$1" mc_version="$2" mod_loader="$3" output_dir="$4"
-    local versions=$(fetch_url "https://api.modrinth.com/v2/project/$project_id/version")
-    local version_file=$(echo "$versions" | $JSON_PROC -r \
-        --arg mc "$mc_version" \
-        --arg loader "$mod_loader" \
-        'map(select((.game_versions | index($mc)) and (.loaders | map(ascii_downcase) | index($loader)))) | .[0]')
-    if [[ "$version_file" == "null" ]] || [[ -z "$version_file" ]]; then
-        print_error "No compatible version for MC $mc_version with $mod_loader"; return 1
-    fi
-    local download_url=$(echo "$version_file" | $JSON_PROC -r '.files[0].url')
-    local filename=$(echo "$version_file" | $JSON_PROC -r '.files[0].filename')
-    [[ -z "$download_url" ]] && { print_error "Failed to get download URL"; return 1; }
-    ensure_dir "$output_dir"
-    local output_file="$output_dir/$filename"
-    [[ -f "$output_file" ]] && { print_info "Already downloaded: $filename"; return 0; }
-    print_info "Downloading $filename..."
-    download_file "$download_url" "$output_file"
-    print_success "Downloaded $filename"
-}
-
-upgrade_all(){
-    local profile_file=$(get_current_profile) || return 1
-    print_header "Upgrading all mods..."
-    local mc_version=$($JSON_PROC -r '.mc_version' < "$profile_file")
-    local mod_loader=$($JSON_PROC -r '.mod_loader' < "$profile_file")
-    local output_dir=$($JSON_PROC -r '.output_dir' < "$profile_file")
-    # Clean output directory
-    if [[ -d "$output_dir" ]]; then
-        print_info "Cleaning output directory..."
-        rm -f "$output_dir"/*.jar
-    fi
-    ensure_dir "$output_dir"
-    local total=$($JSON_PROC -r '.mods | length' < "$profile_file")
-    local count=0
-    $JSON_PROC -c '.mods[]' < "$profile_file" | while IFS= read -r mod; do
-        ((count++))
-        local source=$(echo "$mod" | $JSON_PROC -r '.source')
-        local title=$(echo "$mod" | $JSON_PROC -r '.title')
-        local id=$(echo "$mod" | $JSON_PROC -r '.id')
-        echo ""
-        print_info "[$count/$total] $title"
-        case "$source" in
-            modrinth) download_modrinth_mod "$id" "$mc_version" "$mod_loader" "$output_dir";;
-            curseforge) print_error "CurseForge downloads not yet implemented";;
-            *) print_error "Unknown source: $source";;
-        esac
-    done
-    echo ""
-    print_success "Upgrade complete!"
-}
-
-# ─── Update Operations ──────────────────────────────────────────────────────────
-
-ferium_update(){
-    print_header "Running Ferium mod update..."
+# Update with Ferium
+ferium_update() {
     if ! has_command ferium; then
-        print_error "Ferium not installed. Skipping."
-        print_info "Install from: https://github.com/gorilla-devs/ferium"; return 1
+        print_error "Ferium not installed"
+        return 1
     fi
+    print_header "Running Ferium update"
     ferium scan && ferium upgrade
+    [[ -d mods/.old ]] && rm -rf mods/.old
     print_success "Ferium update complete"
-    # Clean old mod backups
-    if [[ -d mods/.old ]]; then
-        print_info "Cleaning old mod backups..."
-        rm -f mods/.old/*
-        print_success "Cleanup complete"
-    fi
 }
 
-repack_mods(){
-    print_header "Repacking mods with mc-repack..."
+# Repack mods
+repack_mods() {
     if ! has_command mc-repack; then
-        print_error "mc-repack not installed. Skipping."
-        print_info "Install from: https://github.com/jascotty2/mc-repack"; return 1
+        print_error "mc-repack not installed"
+        return 1
     fi
-    local timestamp=$(date +%Y-%m-%d_%H-%M)
+    print_header "Repacking mods"
     local mods_src="${1:-$HOME/Documents/MC/Minecraft/mods}"
-    local mods_dst="${2:-$HOME/Documents/MC/Minecraft/mods-$timestamp}"
+    local mods_dst="${2:-$HOME/Documents/MC/Minecraft/mods-$(date +%Y%m%d_%H%M)}"
+
     [[ ! -d "$mods_src" ]] && { print_error "Source not found: $mods_src"; return 1; }
-    print_info "Source: $mods_src"
-    print_info "Destination: $mods_dst"
+
     mc-repack jars -c "$MC_REPACK_CONFIG" --in "$mods_src" --out "$mods_dst"
     print_success "Repack complete: $mods_dst"
 }
 
-update_geyserconnect(){
-    print_header "Updating GeyserConnect..."
+# Update GeyserConnect
+update_geyserconnect() {
+    print_header "Updating GeyserConnect"
     local dest_dir="${1:-$HOME/Documents/MC/Minecraft/config/Geyser-Fabric/extensions}"
     local url="https://download.geysermc.org/v2/projects/geyserconnect/versions/latest/builds/latest/downloads/geyserconnect"
-    ensure_dir "$dest_dir"
-    local tmp_jar="$dest_dir/GeyserConnect2.jar"
-    local final_jar="$dest_dir/GeyserConnect.jar"
-    print_info "Downloading latest GeyserConnect..."
-    download_file "$url" "$tmp_jar" || { print_error "Download failed"; return 1; }
-    print_success "Download complete"
-    # Backup existing JAR
-    [[ -f "$final_jar" ]] && { print_info "Backing up existing..."; mv "$final_jar" "$final_jar.bak"; }
-    # Repack if available
+
+    mkdir -p "$dest_dir"
+    local jar="$dest_dir/GeyserConnect.jar"
+
+    [[ -f "$jar" ]] && mv "$jar" "$jar.bak"
+
+    download_file "$url" "$jar"
+
     if has_command mc-repack; then
         print_info "Repacking GeyserConnect..."
-        mc-repack jars -c "$MC_REPACK_CONFIG" --in "$tmp_jar" --out "$final_jar"
-        rm -f "$tmp_jar"
-    else
-        mv "$tmp_jar" "$final_jar"
+        local tmp="$jar.tmp"
+        mv "$jar" "$tmp"
+        mc-repack jars -c "$MC_REPACK_CONFIG" --in "$tmp" --out "$jar"
+        rm -f "$tmp"
     fi
-    print_success "GeyserConnect updated: $final_jar"
+
+    print_success "GeyserConnect updated"
 }
 
-# ─── Full Update Workflow ───────────────────────────────────────────────────────
-
-full_update(){
-    print_header "Running full update workflow..."
-    echo ""
+# Full update workflow
+full_update() {
+    print_header "Running full update"
     setup_server
     setup_mc_repack
-    echo ""
     has_command ferium && { ferium_update; echo ""; }
-    [[ -f "$CURRENT_PROFILE" ]] && { upgrade_all 2>/dev/null || :; echo ""; }
     has_command mc-repack && { repack_mods; echo ""; }
     [[ -d "$HOME/Documents/MC/Minecraft/config/Geyser-Fabric" ]] && { update_geyserconnect; echo ""; }
-    print_success "Full update workflow complete!"
+    print_success "Full update complete!"
 }
 
-# ─── Help ───────────────────────────────────────────────────────────────────────
-
-show_help(){
+# Show help
+show_help() {
     cat <<EOF
-Mod Updates - Unified Minecraft mod manager and update system
+Mod Updates - Simplified mod update system
 
 USAGE:
     $0 <COMMAND> [OPTIONS]
 
 COMMANDS:
-    Profile Management:
-        profile create <name> <mc_version> <loader> <output_dir>
-        profile list          List all profiles
-        profile switch <name> Switch to a different profile
-
-    Mod Management:
-        add modrinth <slug>   Add a mod from Modrinth
-        add curseforge <id>   Add a mod from CurseForge
-        list                  List all mods in current profile
-        remove <slug|id>      Remove a mod from current profile
-        upgrade               Download/update all mods in current profile
-
-    System Setup:
-        setup                 Setup server environment (EULA, permissions)
-        setup-repack          Configure mc-repack settings
-
-    Update Operations:
-        ferium                Run ferium scan and upgrade
-        repack [src] [dst]    Repack mods using mc-repack
-        geyserconnect [dir]   Update GeyserConnect extension
-        full-update           Run complete update workflow
-
-    Information:
-        help                  Show this help message
+    setup              Setup server (EULA, permissions)
+    setup-repack       Configure mc-repack
+    ferium             Run ferium update
+    repack [src] [dst] Repack mods with mc-repack
+    geyser [dir]       Update GeyserConnect
+    full-update        Run complete workflow
+    help               Show this help
 
 EXAMPLES:
-    # Setup and full update
     $0 full-update
-
-    # Create profile and add mods
-    $0 profile create fabric-mods 1.21.6 fabric ./mods
-    $0 add modrinth sodium
-    $0 add modrinth lithium
-    $0 upgrade
-
-    # Repack mods
+    $0 ferium
     $0 repack ./mods ./mods-repacked
-
-ENVIRONMENT:
-    XDG_CONFIG_HOME   Config directory (default: ~/.config)
-
-CONFIGURATION:
-    Profiles: $CONFIG_DIR/profiles/
-    mc-repack: $MC_REPACK_CONFIG
 EOF
 }
 
-# ─── Main Command Dispatcher ────────────────────────────────────────────────────
-COMMAND="${1:-}"
-case "$COMMAND" in
-    profile)
-        SUBCOMMAND="${2:-}"
-        case "$SUBCOMMAND" in
-            create) create_profile "$3" "$4" "$5" "$6";;
-            list) list_profiles;;
-            switch) switch_profile "$3";;
-            *) print_error "Unknown profile command: $SUBCOMMAND"; echo "Use: profile [create|list|switch]"; exit 1;;
-        esac;;
-    add)
-        SOURCE="${2:-}"
-        case "$SOURCE" in
-            modrinth) add_modrinth_mod "$3";;
-            curseforge) add_curseforge_mod "$3";;
-            *) print_error "Unknown source: $SOURCE"; echo "Use: add [modrinth|curseforge] <identifier>"; exit 1;;
-        esac;;
-    list) list_mods;;
-    remove) remove_mod "$2";;
-    upgrade) upgrade_all;;
+# Command dispatcher
+case "${1:-}" in
     setup) setup_server;;
     setup-repack) setup_mc_repack;;
     ferium) ferium_update;;
     repack) repack_mods "$2" "$3";;
-    geyserconnect) update_geyserconnect "$2";;
+    geyser|geyserconnect) update_geyserconnect "$2";;
     full-update) full_update;;
     help|--help|-h) show_help;;
     *)
-        if [[ -z "$COMMAND" ]]; then
+        [[ -z "$1" ]] && show_help || {
+            print_error "Unknown command: $1"
             show_help
-        else
-            print_error "Unknown command: $COMMAND"
-            echo ""
-            show_help
-        fi; exit 1;;
+        }
+        exit 1;;
 esac

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,61 +1,39 @@
 #!/usr/bin/env bash
-# prepare.sh: Prepare Minecraft server/client environment with AppCDS archives
+# prepare.sh: Prepare Minecraft server/client environment
 
-# Source common functions (SCRIPT_DIR is auto-initialized)
 source "$(dirname -- "${BASH_SOURCE[0]}")/../lib/common.sh"
 
 init_strict_mode
 
-echo "[*] Minecraft Environment Preparation"
-echo "─────────────────────────────────────────────────────────────"
+print_header "Minecraft Environment Preparation"
 
-# ─── Install Dependencies (Arch Linux only) ─────────────────────────────────────
-if has_command paru; then
-    print_header "Installing dependencies via paru..."
-    paru --noconfirm --skipreview -Sq \
-        ferium jdk25-graalvm-bin gamemode preload \
-        prelockd nohang memavaild adaptivemm uresourced 2>/dev/null || \
-        print_info "Some packages may have failed to install"
-    print_success "Dependencies installation attempted"
-else
-    print_info "paru not found - skipping Arch Linux package installation"
-fi
-if has_command mise; then
-    mise use -g github:zeroBzeroT/ChunkCleaner
-    mise use -g java@oracle-graalvm
-fi
-
-# ─── Calculate Memory Allocation ────────────────────────────────────────────────
+# Calculate Memory Allocation
 TOTAL_RAM=$(get_total_ram_gb)
-SERVER_HEAP=$(get_heap_size_gb 2)  # Reserve 2GB for OS
-CLIENT_HEAP=$(get_client_xmx_gb)   # Use half of RAM for client
+SERVER_HEAP=$(get_heap_size_gb 2)
+CLIENT_HEAP=$(get_client_xmx_gb)
 
-print_header "System Resources"
-echo "  Total RAM: ${TOTAL_RAM}G"
-echo "  Server heap: ${SERVER_HEAP}G"
-echo "  Client heap: ${CLIENT_HEAP}G"
+print_info "Total RAM: ${TOTAL_RAM}G | Server heap: ${SERVER_HEAP}G | Client heap: ${CLIENT_HEAP}G"
 
-# ─── Generate AppCDS Archive for Server ─────────────────────────────────────────
+# Generate AppCDS Archive for Server
 if [[ -f server.jar ]]; then
-    print_header "Generating AppCDS archive for server..."
+    print_info "Generating AppCDS archive for server..."
     java -Xms"${SERVER_HEAP}G" -Xmx"${SERVER_HEAP}G" \
         -XX:ArchiveClassesAtExit=minecraft_server.jsa \
         -jar server.jar --nogui || print_error "Server AppCDS generation failed"
-    [[ -f minecraft_server.jsa ]] && print_success "Server AppCDS archive created: minecraft_server.jsa"
+    [[ -f minecraft_server.jsa ]] && print_success "Server AppCDS archive created"
 else
     print_error "server.jar not found - skipping server preparation"
 fi
 
-# ─── Generate AppCDS Archive for Client ─────────────────────────────────────────
+# Generate AppCDS Archive for Client
 if [[ -f client.jar ]]; then
-    print_header "Generating AppCDS archive for client..."
+    print_info "Generating AppCDS archive for client..."
     java -Xms"${CLIENT_HEAP}G" -Xmx"${CLIENT_HEAP}G" \
         -XX:ArchiveClassesAtExit=minecraft_client.jsa \
         -jar client.jar || print_error "Client AppCDS generation failed"
-    [[ -f minecraft_client.jsa ]] && print_success "Client AppCDS archive created: minecraft_client.jsa"
+    [[ -f minecraft_client.jsa ]] && print_success "Client AppCDS archive created"
 else
     print_info "client.jar not found - skipping client preparation"
 fi
 
-echo "─────────────────────────────────────────────────────────────"
 print_success "Preparation complete!"

--- a/scripts/server-start.sh
+++ b/scripts/server-start.sh
@@ -1,204 +1,70 @@
 #!/usr/bin/env bash
-# server-start.sh: Unified Minecraft server launcher with playit integration
-# Consolidates launcher.sh, start.sh, and Server.sh functionality
+# server-start.sh: Simplified Minecraft server launcher
 
-# Source common functions (SCRIPT_DIR is auto-initialized)
+# Source common functions
 source "$(dirname -- "${BASH_SOURCE[0]}")/../lib/common.sh"
 
 init_strict_mode
 
-# Alias for consistency with rest of script
-has() { has_command "$@"; }
+# Configuration
+: "${SERVER_JAR:=server.jar}"
+: "${ENABLE_PLAYIT:=true}"
+: "${MIN_HEAP_GB:=4}"
 
-# ─── Configuration ──────────────────────────────────────────────────────────────
-# Default settings (override via environment variables)
-: "${MC_JDK:=graalvm}"                    # JDK: graalvm, temurin, or default
-: "${SERVER_JAR:=server.jar}"             # Server jar file
-: "${USE_ALACRITTY:=false}"               # Launch in Alacritty terminal
-: "${ENABLE_PLAYIT:=true}"                # Enable playit for hosting
-: "${ENABLE_OPTIMIZATIONS:=true}"         # Enable system optimizations
-: "${ENABLE_GAMEMODE:=false}"             # Use gamemoderun
-: "${MIN_HEAP_GB:=4}"                     # Minimum heap size
-
-# ─── Validation ─────────────────────────────────────────────────────────────────
+# Validation
 check_dependencies java || exit 1
 [[ ! -f "$SERVER_JAR" ]] && {
     print_error "Server jar not found: ${SERVER_JAR}"
-    print_info "Set SERVER_JAR environment variable or place server.jar in current directory"
     exit 1
 }
 
-# ─── System Optimizations ───────────────────────────────────────────────────────
-if [[ "$ENABLE_OPTIMIZATIONS" == "true" ]]; then
-    print_header "Applying system optimizations..."
-    [[ $EUID -ne 0 ]] && sudo -v
-    echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled &>/dev/null || :
-    echo always | sudo tee /sys/kernel/mm/transparent_hugepage/shmem_enabled &>/dev/null || :
-    [[ -e /sys/block/nvme0n1/queue/scheduler ]] && echo kyber | sudo tee /sys/block/nvme0n1/queue/scheduler &>/dev/null || :
-    has powerprofilesctl && powerprofilesctl set performance &>/dev/null || :
-    echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor &>/dev/null || :
-    sync; echo 3 | sudo tee /proc/sys/vm/drop_caches &>/dev/null || :
-    print_success "System optimizations applied"
-fi
-
-# ─── Memory Configuration ───────────────────────────────────────────────────────
+# Memory Configuration
 CPU_CORES=$(get_cpu_cores)
 HEAP_SIZE=$(get_heap_size_gb 2)
 [[ $HEAP_SIZE -lt $MIN_HEAP_GB ]] && HEAP_SIZE=$MIN_HEAP_GB
 XMS="${HEAP_SIZE}G"
 XMX="${HEAP_SIZE}G"
+
 print_info "Memory: ${XMS} - ${XMX} | CPU Cores: ${CPU_CORES}"
 
-# ─── JDK Detection and Configuration ────────────────────────────────────────────
-if has archlinux-java; then
+# JDK Detection
+JAVA_CMD="java"
+if has_command archlinux-java; then
     sudo archlinux-java fix 2>/dev/null || :
     SEL_JAVA="$(archlinux-java get 2>/dev/null)"
-    JAVA_CMD="${SEL_JAVA:-/usr/lib/jvm/default-runtime/bin/java}"
-elif has mise; then
-    JAVA_CMD="$(mise which java 2>/dev/null)"
-elif [[ -d "${HOME}/.local/share/mise/installs/java/oracle-graalvm-latest" ]]; then
-    JAVA_CMD="${HOME}/.local/share/mise/installs/java/oracle-graalvm-latest/bin/java"
-elif [[ -d "${HOME}/.local/share/mise/installs/java/temurin-latest" ]]; then
-    JAVA_CMD="${HOME}/.local/share/mise/installs/java/temurin-latest/bin/java"
+    [[ -n "$SEL_JAVA" ]] && JAVA_CMD="/usr/lib/jvm/${SEL_JAVA}/bin/java"
+elif has_command mise; then
+    JAVA_CMD="$(mise which java 2>/dev/null)" || JAVA_CMD="java"
 fi
-BASE_FLAGS=(
-    -XX:+UnlockExperimentalVMOptions -XX:+UnlockDiagnosticVMOptions -XX:+IgnoreUnrecognizedVMOptions
-    -Dfile.encoding=UTF-8 -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true --illegal-access=permit
-    -Xlog:async,gc*:file=/dev/null -Djdk.util.zip.disableZip64ExtraFieldValidation=true
-    -Djdk.nio.zipfs.allowDotZipEntry=true -XX:+AlwaysPreTouch -XX:+AlwaysActAsServerClassMachine
-    -XX:+DisableExplicitGC -XX:+UseCompressedOops -XX:-DontCompileHugeMethods
-    -XX:+OptimizeStringConcat -XX:+OptimizeFill
+
+# Simplified JVM Flags
+JVM_FLAGS=(
+    "-Xms${XMS}" "-Xmx${XMX}"
+    -XX:+UseG1GC
+    -XX:+UnlockExperimentalVMOptions
+    -XX:MaxGCPauseMillis=50
+    -XX:G1NewSizePercent=30
+    -XX:G1ReservePercent=15
+    -XX:G1HeapRegionSize=16M
+    -XX:+AlwaysPreTouch
+    -XX:+DisableExplicitGC
+    -XX:+ParallelRefProcEnabled
+    "-XX:ParallelGCThreads=${CPU_CORES}"
+    -Dfile.encoding=UTF-8
 )
-LARGE_PAGES=(-XX:+UseLargePages -XX:LargePageSizeInBytes=2M -XX:+UseLargePagesInMetaspace -XX:+UseTransparentHugePages)
 
-case "$MC_JDK" in
-    graalvm)
-        JAVA_CMD="${JAVA_GRAALVM:-/usr/lib/jvm/default-runtime/bin/java}"
-        [[ ! -x "$JAVA_CMD" ]] && JAVA_CMD=$(command -v java)
-        print_info "Using GraalVM: $JAVA_CMD"
-        JVM_FLAGS=(
-            "${BASE_FLAGS[@]}" "-Xms${XMS}" "-Xmx${XMX}" "${LARGE_PAGES[@]}"
-            # GraalVM JVMCI Compiler
-            -XX:+UseG1GC -XX:+UseJVMCICompiler -XX:+EagerJVMCI
-            -Djdk.graal.CompilerConfiguration=enterprise
-            -Djdk.graal.UsePriorityInlining=true -Djdk.graal.Vectorization=true
-            -Djdk.graal.OptDuplication=true -Djdk.graal.TuneInlinerExploration=1
-            -XX:CompileThreshold=500 -XX:+TieredStopAtLevel=4
-            # GC tuning
-            "-XX:ConcGCThreads=$((CPU_CORES/2))" "-XX:ParallelGCThreads=${CPU_CORES}"
-            -XX:MaxGCPauseMillis=50 -XX:InitiatingHeapOccupancyPercent=15
-            -XX:G1NewSizePercent=30 -XX:G1ReservePercent=15
-            -XX:G1HeapRegionSize=16M -XX:G1MixedGCCountTarget=4
-            # Optimizations
-            -XX:+AggressiveOpts
-            -XX:+UseCompactObjectHeaders
-            -XX:+UseStringDeduplication --add-modules=jdk.incubator.vector -da
-            -XX:+UseCMoveUnconditionally -XX:+UseNewLongLShift
-            -XX:+UseVectorCmov -XX:+UseXmmI2D -XX:+UseXmmI2F -XX:+UseFastAccessorMethods
-        );;
-    temurin)
-        JAVA_CMD="${JAVA_TEMURIN:-/usr/lib/jvm/java-25-temurin/bin/java}"
-        [[ ! -x "$JAVA_CMD" ]] && JAVA_CMD=$(command -v java)
-        print_info "Using Temurin: $JAVA_CMD"
-        JVM_FLAGS=(
-            "${BASE_FLAGS[@]}" "-Xms${XMS}" "-Xmx${XMX}" "${LARGE_PAGES[@]}"
-            # HotSpot C2 Compiler
-            -XX:+UseG1GC -XX:+TieredCompilation -XX:CompileThreshold=1000
-            -XX:ReservedCodeCacheSize=400M -XX:InitialCodeCacheSize=256M
-            # GC tuning
-            "-XX:ConcGCThreads=$((CPU_CORES/2))" "-XX:ParallelGCThreads=${CPU_CORES}"
-            -XX:MaxGCPauseMillis=50 -XX:InitiatingHeapOccupancyPercent=30
-            -XX:G1NewSizePercent=35 -XX:G1ReservePercent=20
-            -XX:G1HeapRegionSize=16M -XX:G1MixedGCCountTarget=3
-            -XX:MaxTenuringThreshold=1 -XX:SurvivorRatio=8
-            -XX:+ParallelRefProcEnabled -XX:+UseTLAB
-            # Optimizations
-            -XX:+AggressiveOpts
-            -XX:+UseCompactObjectHeaders
-            -XX:+UseStringDeduplication --add-modules=jdk.incubator.vector -da
-            -XX:+UseCMoveUnconditionally -XX:+UseNewLongLShift
-            -XX:+UseVectorCmov -XX:+UseXmmI2D -XX:+UseXmmI2F
-            -XX:+UseFastAccessorMethods -XX:+UseInlineCaches
-            -XX:+RangeCheckElimination -XX:+EliminateLocks
-        );;
-    fabric|default|*)
-        JAVA_CMD="${JAVA_CMD:-$(command -v java 2>/dev/null)}"
-        print_info "Using Default JDK: $JAVA_CMD"
-        JVM_FLAGS=(
-            # Memory
-            "${BASE_FLAGS[@]}" "-Xms${XMS}" "-Xmx${XMX}" "${LARGE_PAGES[@]}"
-            # GC Configuration
-            -XX:+UseG1GC
-            -XX:MaxGCPauseMillis=130 -XX:G1NewSizePercent=28 -XX:G1HeapRegionSize=16M
-            -XX:G1ReservePercent=20 -XX:G1MixedGCCountTarget=3
-            -XX:InitiatingHeapOccupancyPercent=10 -XX:G1MixedGCLiveThresholdPercent=90
-            -XX:G1RSetUpdatingPauseTimePercent=0 -XX:SurvivorRatio=32 -XX:MaxTenuringThreshold=1
-            -XX:G1SATBBufferEnqueueingThresholdPercent=30 -XX:G1ConcMarkStepDurationMillis=5.0
-            -XX:AllocatePrefetchStyle=3 -XX:ConcGCThreads=2
-            # Code Cache
-            -XX:ReservedCodeCacheSize=400M -XX:NonNMethodCodeHeapSize=12M
-            -XX:ProfiledCodeHeapSize=194M -XX:NonProfiledCodeHeapSize=194M
-            -XX:+SegmentedCodeCache
-            # Compiler
-            -XX:MaxNodeLimit=240000 -XX:NodeLimitFudgeFactor=8000
-            -XX:NmethodSweepActivity=1
-            # Performance
-            -XX:+UseStringDeduplication -XX:+UseFMA -XX:+ParallelRefProcEnabled
-            -XX:+UseTLAB
-            -XX:+RangeCheckElimination -XX:+UseLoopPredicate -XX:+OmitStackTraceInFastThrow
-            -XX:+UseNewLongLShift -XX:+UseFPUForSpilling -XX:+EliminateLocks
-            # Vector & SIMD
-            -XX:+EnableVectorSupport -XX:+UseVectorStubs -XX:+UseVectorCmov
-            # Memory & Cache
-            -XX:+UseFastJNIAccessors -XX:+UseInlineCaches -XX:+PerfDisableSharedMem
-            # Thread Priority
-            -XX:+UseCriticalJavaThreadPriority -XX:ThreadPriorityPolicy=1
-            -XX:+UseFastUnorderedTimeStamps
-        );;
-esac
-
-# ─── Playit Integration ─────────────────────────────────────────────────────────
-if [[ "$ENABLE_PLAYIT" == "true" ]] && has playit; then
-    print_info "Starting playit for server hosting..."
-    { setsid nohup playit &>/dev/null & } || print_error "Failed to start playit"
-    read -rt 2 -- <> <(:) &>/dev/null || :
-elif [[ "$ENABLE_PLAYIT" == "true" ]]; then
-    print_info "playit not found. Install from: https://playit.gg"
+# Playit Integration
+if [[ "$ENABLE_PLAYIT" == "true" ]] && has_command playit; then
+    print_info "Starting playit..."
+    { setsid nohup playit &>/dev/null & } || :
+    sleep 2
 fi
 
-# ─── Launch Server ──────────────────────────────────────────────────────────────
-LAUNCH_CMD=()
-# CPU affinity
-if has taskset && [[ "$ENABLE_OPTIMIZATIONS" == "true" ]]; then
-    LAUNCH_CMD+=(taskset -c "0-$((CPU_CORES-1))")
-    print_info "CPU affinity: cores 0-$((CPU_CORES-1))"
-fi
-# Gamemode
-if [[ "$ENABLE_GAMEMODE" == "true" ]] && has gamemoderun; then
-    LAUNCH_CMD+=(sudo gamemoderun)
-    print_info "Using gamemoderun"
-fi
-LAUNCH_CMD+=("$JAVA_CMD" "${JVM_FLAGS[@]}" -jar "$SERVER_JAR" --nogui)
-
-echo ""
-echo "─────────────────────────────────────────────────────────────"
+# Launch Server
 print_header "Starting Minecraft Server"
 echo "  JAR: ${SERVER_JAR}"
 echo "  Memory: ${XMS} - ${XMX}"
 echo "  CPU Cores: ${CPU_CORES}"
-echo "─────────────────────────────────────────────────────────────"
 echo ""
 
-# Launch
-if [[ "$USE_ALACRITTY" == "true" ]] && has alacritty; then
-    print_info "Launching in Alacritty..."
-    alacritty -e bash -c "${LAUNCH_CMD[*]}"
-elif command -v rio &>/dev/null; then
-  print_info "Launching in Rio..."
-  rio -e bash -c "${LAUNCH_CMD[*]}"
-elif command -v ghostty &>/dev/null; then
-  print_info "Launching in Ghostty..."
-  ghostty -e bash -c "${LAUNCH_CMD[*]}"
-else
-  exec "${LAUNCH_CMD[@]}"
-fi
+exec "$JAVA_CMD" "${JVM_FLAGS[@]}" -jar "$SERVER_JAR" --nogui

--- a/tools/backup.sh
+++ b/tools/backup.sh
@@ -1,323 +1,135 @@
 #!/usr/bin/env bash
-# Minecraft Server Backup Tool
-# Automated backup solution for worlds, configurations, and plugins
+# Simplified Minecraft server backup tool
 
-# Source common functions (SCRIPT_DIR is auto-initialized)
 source "$(dirname -- "${BASH_SOURCE[0]}")/../lib/common.sh"
 
 init_strict_mode
 
 # Configuration
-SERVER_DIR="$SCRIPT_DIR"
-BACKUP_DIR="${SERVER_DIR}/backups"
+BACKUP_DIR="${SCRIPT_DIR}/backups"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-MAX_BACKUPS=10  # Keep last 10 backups
+MAX_BACKUPS=10
 
-# Logging functions (wrapper around common.sh functions for consistency)
-log_info() { print_info "$*"; }
-log_success() { print_success "$*"; }
-log_warning() { print_info "$*"; }  # common.sh doesn't have print_warning
-log_error() { print_error "$*"; }
-
-# Create backup directory structure
-init_backup_dir() {
-    mkdir -p "${BACKUP_DIR}/worlds"
-    mkdir -p "${BACKUP_DIR}/configs"
-    mkdir -p "${BACKUP_DIR}/temp"
-}
+# Initialize backup directories
+mkdir -p "${BACKUP_DIR}/worlds" "${BACKUP_DIR}/configs"
 
 # Backup world data
 backup_world() {
-    local backup_name="world_${TIMESTAMP}.tar.gz"
-    local backup_path="${BACKUP_DIR}/worlds/${backup_name}"
+    print_info "Backing up world..."
+    [[ ! -d "${SCRIPT_DIR}/world" ]] && { print_error "No world directory found"; return 1; }
 
-    log_info "Backing up world data..."
+    cd "${SCRIPT_DIR}"
+    tar -czf "${BACKUP_DIR}/worlds/world_${TIMESTAMP}.tar.gz" world/ world_nether/ world_the_end/ 2>/dev/null || \
+        tar -czf "${BACKUP_DIR}/worlds/world_${TIMESTAMP}.tar.gz" world/
 
-    if [ -d "${SERVER_DIR}/world" ]; then
-        cd "${SERVER_DIR}"
-        tar -czf "${backup_path}" world/ world_nether/ world_the_end/ 2>/dev/null || \
-            tar -czf "${backup_path}" world/ 2>/dev/null || {
-                log_error "Failed to backup world data"
-                return 1
-            }
-
-        local size=$(du -h "${backup_path}" | cut -f1)
-        log_success "World backup created: ${backup_name} (${size})"
-        return 0
-    else
-        log_warning "No world directory found, skipping world backup"
-        return 1
-    fi
+    print_success "World backup created: world_${TIMESTAMP}.tar.gz"
 }
 
-# Backup configuration files
+# Backup configs
 backup_configs() {
-    local backup_name="config_${TIMESTAMP}.tar.gz"
-    local backup_path="${BACKUP_DIR}/configs/${backup_name}"
+    print_info "Backing up configs..."
+    cd "${SCRIPT_DIR}"
+    tar -czf "${BACKUP_DIR}/configs/config_${TIMESTAMP}.tar.gz" \
+        --exclude='*.jar' --exclude='mods' --exclude='world*' --exclude='logs' \
+        --exclude='crash-reports' --exclude='backups' \
+        config/ server.properties *.yml *.yaml *.toml *.ini *.json *.json5 2>/dev/null
 
-    log_info "Backing up configuration files..."
-
-    cd "${SERVER_DIR}"
-    tar -czf "${backup_path}" \
-        --exclude='*.jar' \
-        --exclude='mods' \
-        --exclude='world*' \
-        --exclude='logs' \
-        --exclude='crash-reports' \
-        --exclude='backups' \
-        config/ server.properties *.yml *.yaml *.toml *.ini *.json *.json5 2>/dev/null || {
-            log_error "Failed to backup configuration files"
-            return 1
-        }
-
-    local size=$(du -h "${backup_path}" | cut -f1)
-    log_success "Config backup created: ${backup_name} (${size})"
-    return 0
+    print_success "Config backup created: config_${TIMESTAMP}.tar.gz"
 }
 
-# Backup mods directory
+# Backup mods
 backup_mods() {
-    local backup_name="mods_${TIMESTAMP}.tar.gz"
-    local backup_path="${BACKUP_DIR}/configs/${backup_name}"
+    print_info "Backing up mods..."
+    [[ ! -d "${SCRIPT_DIR}/mods" ]] && { print_info "No mods directory"; return 0; }
 
-    log_info "Backing up mods directory..."
+    cd "${SCRIPT_DIR}"
+    tar -czf "${BACKUP_DIR}/configs/mods_${TIMESTAMP}.tar.gz" mods/
 
-    if [ -d "${SERVER_DIR}/mods" ]; then
-        cd "${SERVER_DIR}"
-        tar -czf "${backup_path}" mods/ || {
-            log_error "Failed to backup mods"
-            return 1
-        }
-
-        local size=$(du -h "${backup_path}" | cut -f1)
-        log_success "Mods backup created: ${backup_name} (${size})"
-        return 0
-    else
-        log_warning "No mods directory found, skipping mods backup"
-        return 1
-    fi
+    print_success "Mods backup created: mods_${TIMESTAMP}.tar.gz"
 }
 
 # Clean old backups
 cleanup_old_backups() {
-    log_info "Cleaning up old backups (keeping last ${MAX_BACKUPS})..."
+    print_info "Cleaning old backups (keeping last ${MAX_BACKUPS})..."
 
-    # Clean old world backups
-    if [ -d "${BACKUP_DIR}/worlds" ]; then
-        local count=$(find "${BACKUP_DIR}/worlds" -name "world_*.tar.gz" | wc -l)
-        if [ "$count" -gt "$MAX_BACKUPS" ]; then
-            find "${BACKUP_DIR}/worlds" -name "world_*.tar.gz" -type f -printf '%T@ %p\n' | \
+    for dir in worlds configs; do
+        local count=$(find "${BACKUP_DIR}/${dir}" -name "*.tar.gz" 2>/dev/null | wc -l)
+        if [[ $count -gt $MAX_BACKUPS ]]; then
+            find "${BACKUP_DIR}/${dir}" -name "*.tar.gz" -type f -printf '%T@ %p\n' | \
                 sort -n | head -n -${MAX_BACKUPS} | cut -d' ' -f2- | xargs rm -f
-            log_success "Removed old world backups"
         fi
-    fi
+    done
 
-    # Clean old config backups
-    if [ -d "${BACKUP_DIR}/configs" ]; then
-        local count=$(find "${BACKUP_DIR}/configs" -name "config_*.tar.gz" | wc -l)
-        if [ "$count" -gt "$MAX_BACKUPS" ]; then
-            find "${BACKUP_DIR}/configs" -name "config_*.tar.gz" -type f -printf '%T@ %p\n' | \
-                sort -n | head -n -${MAX_BACKUPS} | cut -d' ' -f2- | xargs rm -f
-            log_success "Removed old config backups"
-        fi
-    fi
+    print_success "Cleanup complete"
 }
 
-# List available backups
+# List backups
 list_backups() {
-    log_info "Available backups:"
+    print_header "Available backups"
     echo ""
-
-    if [ -d "${BACKUP_DIR}/worlds" ]; then
-        echo "World Backups:"
-        find "${BACKUP_DIR}/worlds" -name "world_*.tar.gz" -type f -printf '%T@ %p\n' | \
-            sort -rn | while read -r timestamp path; do
-                local size=$(du -h "$path" | cut -f1)
-                local date=$(date -d "@${timestamp%.*}" '+%Y-%m-%d %H:%M:%S')
-                echo "  - $(basename "$path") (${size}, ${date})"
-            done
-        echo ""
-    fi
-
-    if [ -d "${BACKUP_DIR}/configs" ]; then
-        echo "Config Backups:"
-        find "${BACKUP_DIR}/configs" -name "config_*.tar.gz" -type f -printf '%T@ %p\n' | \
-            sort -rn | head -n 5 | while read -r timestamp path; do
-                local size=$(du -h "$path" | cut -f1)
-                local date=$(date -d "@${timestamp%.*}" '+%Y-%m-%d %H:%M:%S')
-                echo "  - $(basename "$path") (${size}, ${date})"
-            done
-        echo ""
-    fi
+    echo "World Backups:"
+    find "${BACKUP_DIR}/worlds" -name "*.tar.gz" 2>/dev/null | sort -r | head -10 | while read -r f; do
+        echo "  $(basename "$f") ($(du -h "$f" | cut -f1))"
+    done
+    echo ""
+    echo "Config Backups:"
+    find "${BACKUP_DIR}/configs" -name "*.tar.gz" 2>/dev/null | sort -r | head -10 | while read -r f; do
+        echo "  $(basename "$f") ($(du -h "$f" | cut -f1))"
+    done
 }
 
 # Restore backup
 restore_backup() {
-    local backup_file="$1"
+    local file="$1"
+    [[ ! -f "$file" ]] && { print_error "File not found: $file"; exit 1; }
 
-    if [ ! -f "$backup_file" ]; then
-        log_error "Backup file not found: $backup_file"
-        return 1
-    fi
+    print_info "Restoring: $(basename "$file")"
+    read -p "This will overwrite existing data. Continue? (yes/no): " confirm
+    [[ "$confirm" != "yes" ]] && { print_info "Cancelled"; exit 0; }
 
-    log_warning "This will restore backup and may overwrite existing data!"
-    read -p "Are you sure you want to continue? (yes/no): " confirm
-
-    if [ "$confirm" != "yes" ]; then
-        log_info "Restore cancelled"
-        return 0
-    fi
-
-    log_info "Restoring backup: $(basename "$backup_file")"
-    cd "${SERVER_DIR}"
-    tar -xzf "$backup_file" || {
-        log_error "Failed to restore backup"
-        return 1
-    }
-
-    log_success "Backup restored successfully"
-    return 0
-}
-
-# Send command to running server (requires screen or tmux)
-send_server_command() {
-    local cmd="$1"
-
-    # Try screen first
-    if screen -list | grep -q "minecraft"; then
-        screen -S minecraft -X stuff "${cmd}^M"
-        return 0
-    fi
-
-    # Try tmux
-    if tmux list-sessions 2>/dev/null | grep -q "minecraft"; then
-        tmux send-keys -t minecraft "${cmd}" Enter
-        return 0
-    fi
-
-    return 1
-}
-
-# Create backup with server notifications
-backup_with_notification() {
-    local do_world="${1:-true}"
-    local do_config="${2:-true}"
-    local do_mods="${3:-false}"
-
-    # Notify players if server is running
-    if send_server_command "say Backup starting in 10 seconds..."; then
-        log_info "Notified players, waiting 10 seconds..."
-        sleep 10
-
-        # Save world and disable auto-save
-        send_server_command "save-all"
-        sleep 2
-        send_server_command "save-off"
-        log_info "World saved, auto-save disabled"
-    fi
-
-    # Perform backups
-    [ "$do_world" = true ] && backup_world
-    [ "$do_config" = true ] && backup_configs
-    [ "$do_mods" = true ] && backup_mods
-
-    # Re-enable auto-save
-    if send_server_command "save-on"; then
-        send_server_command "say Backup complete!"
-        log_success "Backup complete, auto-save re-enabled"
-    fi
-
-    # Cleanup old backups
-    cleanup_old_backups
+    cd "${SCRIPT_DIR}"
+    tar -xzf "$file"
+    print_success "Restore complete"
 }
 
 # Show usage
 show_usage() {
-    cat << EOF
+    cat <<EOF
 Minecraft Server Backup Tool
 
-Usage: $(basename "$0") [command] [options]
+Usage: $0 [command] [options]
 
 Commands:
     backup [world|config|mods|all]  Create backup (default: all)
-    list                            List available backups
-    restore <backup_file>           Restore from backup
+    list                            List backups
+    restore <file>                  Restore backup
     cleanup                         Clean old backups
-    help                            Show this help message
+    help                            Show this help
 
 Options:
-    --max-backups <num>            Number of backups to keep (default: 10)
+    --max-backups <num>            Keep N backups (default: 10)
 
 Examples:
-    $(basename "$0") backup             # Backup everything
-    $(basename "$0") backup world       # Backup only world
-    $(basename "$0") list               # List all backups
-    $(basename "$0") restore backups/worlds/world_20250119_120000.tar.gz
-    $(basename "$0") cleanup            # Remove old backups
-
+    $0 backup
+    $0 backup world
+    $0 list
+    $0 restore backups/worlds/world_20250119_120000.tar.gz
 EOF
 }
 
-# Main function
-main() {
-    # Parse options
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --max-backups)
-                MAX_BACKUPS="$2"
-                shift 2
-                ;;
-            backup)
-                shift
-                init_backup_dir
-
-                case "${1:-all}" in
-                    world)
-                        backup_with_notification true false false
-                        ;;
-                    config)
-                        backup_with_notification false true false
-                        ;;
-                    mods)
-                        backup_with_notification false false true
-                        ;;
-                    all|*)
-                        backup_with_notification true true true
-                        ;;
-                esac
-                exit 0
-                ;;
-            list)
-                list_backups
-                exit 0
-                ;;
-            restore)
-                if [ -z "${2:-}" ]; then
-                    log_error "Please specify backup file to restore"
-                    exit 1
-                fi
-                restore_backup "$2"
-                exit 0
-                ;;
-            cleanup)
-                cleanup_old_backups
-                exit 0
-                ;;
-            help|--help|-h)
-                show_usage
-                exit 0
-                ;;
-            *)
-                log_error "Unknown command: $1"
-                show_usage
-                exit 1
-                ;;
+# Main
+case "${1:-backup}" in
+    backup)
+        case "${2:-all}" in
+            world) backup_world;;
+            config) backup_configs;;
+            mods) backup_mods;;
+            all|*) backup_world; backup_configs; backup_mods;;
         esac
-    done
-
-    # Default action
-    show_usage
-}
-
-# Run main function
-main "$@"
+        cleanup_old_backups;;
+    list) list_backups;;
+    restore) restore_backup "$2";;
+    cleanup) cleanup_old_backups;;
+    help|--help|-h) show_usage;;
+    *) print_error "Unknown command: $1"; show_usage; exit 1;;
+esac

--- a/tools/logrotate.sh
+++ b/tools/logrotate.sh
@@ -1,414 +1,240 @@
 #!/usr/bin/env bash
-# Minecraft Server Log Management and Rotation
-# Clean, compress, and manage server logs
+# Simplified Minecraft server log management
 
-# Source common functions (SCRIPT_DIR is auto-initialized)
 source "$(dirname -- "${BASH_SOURCE[0]}")/../lib/common.sh"
 
 init_strict_mode
 
 # Configuration
-SERVER_DIR="$SCRIPT_DIR"
-LOGS_DIR="${SERVER_DIR}/logs"
+LOGS_DIR="${SCRIPT_DIR}/logs"
 ARCHIVE_DIR="${LOGS_DIR}/archive"
 MAX_LOG_AGE_DAYS=30
 MAX_ARCHIVED_LOGS=50
 LOG_SIZE_LIMIT_MB=100
 
-# Logging functions (wrapper around common.sh functions for consistency)
-log_info() { print_info "$*"; }
-log_success() { print_success "$*"; }
-log_warning() { print_info "$*"; }  # common.sh doesn't have print_warning
-log_error() { print_error "$*"; }
+# Initialize
+mkdir -p "$ARCHIVE_DIR"
 
-# Initialize archive directory
-init_archive() {
-    mkdir -p "$ARCHIVE_DIR"
-}
-
-# Get file size in MB
-get_size_mb() {
-    local file="$1"
-    if [ -f "$file" ]; then
-        local size_kb=$(du -k "$file" | cut -f1)
-        echo $((size_kb / 1024))
-    else
-        echo "0"
-    fi
-}
-
-# Rotate current log file
+# Rotate log file
 rotate_log() {
     local log_file="$1"
-    local log_name=$(basename "$log_file")
+    [[ ! -f "$log_file" ]] && return 1
 
-    if [ ! -f "$log_file" ]; then
-        log_warning "Log file not found: $log_file"
-        return 1
-    fi
+    local size_mb=$(du -m "$log_file" 2>/dev/null | cut -f1)
+    [[ $size_mb -eq 0 ]] && return 0
 
-    local size_mb=$(get_size_mb "$log_file")
-    if [ "$size_mb" -eq 0 ]; then
-        log_info "Log file is empty: $log_name"
-        return 0
-    fi
+    print_info "Rotating $(basename "$log_file") (${size_mb}MB)..."
 
-    log_info "Rotating log: $log_name (${size_mb}MB)"
-
-    # Create timestamped filename
     local timestamp=$(date +%Y%m%d_%H%M%S)
-    local archived_name="${log_name%.log}_${timestamp}.log"
+    local name=$(basename "$log_file" .log)
+    local archived="${ARCHIVE_DIR}/${name}_${timestamp}.log"
 
-    # Move and compress
-    cp "$log_file" "${ARCHIVE_DIR}/${archived_name}"
-    gzip "${ARCHIVE_DIR}/${archived_name}"
-
-    # Clear original log (don't delete, just truncate)
+    cp "$log_file" "$archived"
+    gzip "$archived"
     : > "$log_file"
 
-    log_success "Log rotated and compressed: ${archived_name}.gz (${size_mb}MB)"
+    print_success "Rotated: ${name}_${timestamp}.log.gz"
 }
 
-# Rotate all server logs
-rotate_all_logs() {
-    log_info "Rotating all server logs..."
+# Rotate all logs
+rotate_all() {
+    print_header "Rotating logs"
 
-    init_archive
+    [[ -f "${LOGS_DIR}/latest.log" ]] && rotate_log "${LOGS_DIR}/latest.log"
+    [[ -f "${LOGS_DIR}/debug.log" ]] && rotate_log "${LOGS_DIR}/debug.log"
 
-    # Rotate main server log
-    if [ -f "${LOGS_DIR}/latest.log" ]; then
-        rotate_log "${LOGS_DIR}/latest.log"
-    fi
-
-    # Rotate debug log
-    if [ -f "${LOGS_DIR}/debug.log" ]; then
-        rotate_log "${LOGS_DIR}/debug.log"
-    fi
-
-    # Rotate watchdog log
-    if [ -f "${LOGS_DIR}/watchdog.log" ]; then
-        local size_mb=$(get_size_mb "${LOGS_DIR}/watchdog.log")
-        if [ "$size_mb" -gt "$LOG_SIZE_LIMIT_MB" ]; then
-            rotate_log "${LOGS_DIR}/watchdog.log"
-        fi
-    fi
-
-    # Rotate dated logs (e.g., 2025-11-19-1.log.gz)
-    find "$LOGS_DIR" -maxdepth 1 -name "*.log" -type f | while read -r log_file; do
-        local size_mb=$(get_size_mb "$log_file")
-        if [ "$size_mb" -gt "$LOG_SIZE_LIMIT_MB" ]; then
-            rotate_log "$log_file"
-        fi
+    # Rotate large logs
+    find "$LOGS_DIR" -maxdepth 1 -name "*.log" -type f | while read -r log; do
+        local size_mb=$(du -m "$log" 2>/dev/null | cut -f1)
+        [[ $size_mb -gt $LOG_SIZE_LIMIT_MB ]] && rotate_log "$log"
     done
 
-    log_success "Log rotation complete"
+    print_success "Rotation complete"
 }
 
-# Compress old uncompressed logs
-compress_old_logs() {
-    log_info "Compressing old uncompressed logs..."
+# Compress old logs
+compress_old() {
+    print_header "Compressing old logs"
 
     local count=0
 
-    # Compress logs in main logs directory
-    find "$LOGS_DIR" -maxdepth 1 -name "*.log" -type f -mtime +1 | while read -r log_file; do
-        if [ "$(basename "$log_file")" != "latest.log" ] && \
-           [ "$(basename "$log_file")" != "debug.log" ] && \
-           [ "$(basename "$log_file")" != "watchdog.log" ]; then
-            log_info "Compressing: $(basename "$log_file")"
-            gzip "$log_file"
+    # Compress in logs directory
+    find "$LOGS_DIR" -maxdepth 1 -name "*.log" -type f -mtime +1 | while read -r log; do
+        local name=$(basename "$log")
+        [[ "$name" != "latest.log" && "$name" != "debug.log" && "$name" != "watchdog.log" ]] && {
+            print_info "Compressing: $name"
+            gzip "$log"
             ((count++))
-        fi
+        }
     done
 
-    # Compress logs in archive directory
-    find "$ARCHIVE_DIR" -name "*.log" -type f | while read -r log_file; do
-        log_info "Compressing: $(basename "$log_file")"
-        gzip "$log_file"
+    # Compress in archive
+    find "$ARCHIVE_DIR" -name "*.log" -type f | while read -r log; do
+        print_info "Compressing: $(basename "$log")"
+        gzip "$log"
         ((count++))
     done
 
-    if [ "$count" -gt 0 ]; then
-        log_success "Compressed $count log files"
-    else
-        log_info "No logs to compress"
-    fi
+    [[ $count -gt 0 ]] && print_success "Compressed $count files" || print_info "Nothing to compress"
 }
 
 # Clean old logs
-clean_old_logs() {
-    log_info "Cleaning logs older than ${MAX_LOG_AGE_DAYS} days..."
-
-    init_archive
+clean_old() {
+    print_header "Cleaning logs older than ${MAX_LOG_AGE_DAYS} days"
 
     local count=0
 
-    # Delete old logs from main directory
-    find "$LOGS_DIR" -maxdepth 1 \( -name "*.log.gz" -o -name "*.log" \) -type f -mtime +${MAX_LOG_AGE_DAYS} | while read -r log_file; do
-        log_info "Deleting old log: $(basename "$log_file")"
-        rm -f "$log_file"
+    find "$LOGS_DIR" -maxdepth 1 \( -name "*.log.gz" -o -name "*.log" \) -type f -mtime +${MAX_LOG_AGE_DAYS} | while read -r log; do
+        print_info "Deleting: $(basename "$log")"
+        rm -f "$log"
         ((count++))
     done
 
-    # Delete old logs from archive
-    find "$ARCHIVE_DIR" -name "*.log.gz" -type f -mtime +${MAX_LOG_AGE_DAYS} | while read -r log_file; do
-        log_info "Deleting old archive: $(basename "$log_file")"
-        rm -f "$log_file"
+    find "$ARCHIVE_DIR" -name "*.log.gz" -type f -mtime +${MAX_LOG_AGE_DAYS} | while read -r log; do
+        print_info "Deleting: $(basename "$log")"
+        rm -f "$log"
         ((count++))
     done
 
-    if [ "$count" -gt 0 ]; then
-        log_success "Deleted $count old log files"
-    else
-        log_info "No old logs to delete"
-    fi
+    [[ $count -gt 0 ]] && print_success "Deleted $count files" || print_info "Nothing to clean"
 }
 
-# Limit number of archived logs
-limit_archived_logs() {
-    log_info "Limiting archived logs to ${MAX_ARCHIVED_LOGS} most recent..."
-
-    if [ ! -d "$ARCHIVE_DIR" ]; then
-        return 0
-    fi
+# Limit archived logs
+limit_archives() {
+    print_header "Limiting archives to ${MAX_ARCHIVED_LOGS}"
 
     local count=$(find "$ARCHIVE_DIR" -name "*.log.gz" -type f | wc -l)
+    [[ $count -le $MAX_ARCHIVED_LOGS ]] && { print_info "Archive count ($count) OK"; return 0; }
 
-    if [ "$count" -le "$MAX_ARCHIVED_LOGS" ]; then
-        log_info "Archive count ($count) within limit"
-        return 0
-    fi
-
-    log_info "Found $count archived logs, removing oldest..."
-
-    # Delete oldest logs
+    print_info "Removing oldest archives..."
     find "$ARCHIVE_DIR" -name "*.log.gz" -type f -printf '%T@ %p\n' | \
-        sort -n | head -n -${MAX_ARCHIVED_LOGS} | cut -d' ' -f2- | \
-        while read -r log_file; do
-            log_info "Removing: $(basename "$log_file")"
-            rm -f "$log_file"
+        sort -n | head -n -${MAX_ARCHIVED_LOGS} | cut -d' ' -f2- | while read -r log; do
+            rm -f "$log"
         done
 
-    log_success "Archive cleaned"
+    print_success "Archives cleaned"
 }
 
-# Show log statistics
+# Show statistics
 show_stats() {
     echo ""
-    echo "═══════════════════════════════════════════════════════════"
-    echo "           Log Management Statistics"
-    echo "═══════════════════════════════════════════════════════════"
+    echo "═══════════════════════════════════════════"
+    echo "        Log Management Statistics"
+    echo "═══════════════════════════════════════════"
     echo ""
 
-    # Current logs
-    if [ -d "$LOGS_DIR" ]; then
-        local current_count=$(find "$LOGS_DIR" -maxdepth 1 -name "*.log*" -type f | wc -l)
-        local current_size=$(du -sh "$LOGS_DIR" 2>/dev/null | cut -f1)
+    if [[ -d "$LOGS_DIR" ]]; then
+        local count=$(find "$LOGS_DIR" -maxdepth 1 -name "*.log*" -type f | wc -l)
+        local size=$(du -sh "$LOGS_DIR" 2>/dev/null | cut -f1)
         echo "Current Logs:"
-        echo "  Count: $current_count"
-        echo "  Total Size: $current_size"
+        echo "  Count: $count"
+        echo "  Size: $size"
         echo ""
 
-        # Show active logs
         echo "Active Logs:"
         for log in latest.log debug.log watchdog.log; do
-            if [ -f "${LOGS_DIR}/${log}" ]; then
-                local size=$(du -h "${LOGS_DIR}/${log}" 2>/dev/null | cut -f1)
+            [[ -f "${LOGS_DIR}/${log}" ]] && {
+                local s=$(du -h "${LOGS_DIR}/${log}" 2>/dev/null | cut -f1)
                 local lines=$(wc -l < "${LOGS_DIR}/${log}")
-                echo "  - ${log}: ${size} (${lines} lines)"
-            fi
+                echo "  ${log}: ${s} (${lines} lines)"
+            }
         done
         echo ""
     fi
 
-    # Archived logs
-    if [ -d "$ARCHIVE_DIR" ]; then
-        local archive_count=$(find "$ARCHIVE_DIR" -name "*.log.gz" -type f | wc -l)
-        local archive_size=$(du -sh "$ARCHIVE_DIR" 2>/dev/null | cut -f1)
-        echo "Archived Logs:"
-        echo "  Count: $archive_count"
-        echo "  Total Size: $archive_size"
-        echo ""
-
-        # Show newest archives
-        echo "Recent Archives:"
-        find "$ARCHIVE_DIR" -name "*.log.gz" -type f -printf '%T@ %p\n' | \
-            sort -rn | head -5 | while read -r timestamp path; do
-                local size=$(du -h "$path" 2>/dev/null | cut -f1)
-                local date=$(date -d "@${timestamp%.*}" '+%Y-%m-%d %H:%M:%S')
-                echo "  - $(basename "$path") (${size}, ${date})"
-            done
+    if [[ -d "$ARCHIVE_DIR" ]]; then
+        local count=$(find "$ARCHIVE_DIR" -name "*.log.gz" -type f | wc -l)
+        local size=$(du -sh "$ARCHIVE_DIR" 2>/dev/null | cut -f1)
+        echo "Archives:"
+        echo "  Count: $count"
+        echo "  Size: $size"
         echo ""
     fi
 
-    # Crash reports
-    if [ -d "${SERVER_DIR}/crash-reports" ]; then
-        local crash_count=$(find "${SERVER_DIR}/crash-reports" -name "crash-*.txt" -type f | wc -l)
-        if [ "$crash_count" -gt 0 ]; then
-            echo "Crash Reports: $crash_count"
-            echo "  Location: crash-reports/"
-            echo ""
-        fi
-    fi
-
-    echo "═══════════════════════════════════════════════════════════"
+    echo "═══════════════════════════════════════════"
 }
 
-# View log file
+# View log
 view_log() {
-    local log_name="${1:-latest.log}"
+    local log="${1:-latest.log}"
     local lines="${2:-50}"
+    local path="${LOGS_DIR}/${log}"
 
-    local log_path="${LOGS_DIR}/${log_name}"
+    [[ ! -f "$path" ]] && { print_error "Log not found: $log"; return 1; }
 
-    if [ ! -f "$log_path" ]; then
-        log_error "Log file not found: $log_name"
-        return 1
-    fi
-
-    log_info "Showing last $lines lines of $log_name:"
+    print_info "Last $lines lines of $log:"
     echo ""
-    tail -n "$lines" "$log_path"
+    tail -n "$lines" "$path"
 }
 
 # Search logs
-search_logs() {
+search_log() {
     local pattern="$1"
-    local log_name="${2:-latest.log}"
+    local log="${2:-latest.log}"
+    local path="${LOGS_DIR}/${log}"
 
-    local log_path="${LOGS_DIR}/${log_name}"
+    [[ ! -f "$path" ]] && { print_error "Log not found: $log"; return 1; }
 
-    if [ ! -f "$log_path" ]; then
-        log_error "Log file not found: $log_name"
-        return 1
-    fi
-
-    log_info "Searching for '$pattern' in $log_name:"
+    print_info "Searching for '$pattern' in $log:"
     echo ""
-    grep --color=auto -i "$pattern" "$log_path" || log_warning "No matches found"
+    grep --color=auto -i "$pattern" "$path" || print_info "No matches"
 }
 
-# Full maintenance - rotate, compress, clean
+# Full maintenance
 full_maintenance() {
-    log_info "Starting full log maintenance..."
+    print_header "Full log maintenance"
     echo ""
-
-    rotate_all_logs
+    rotate_all
     echo ""
-
-    compress_old_logs
+    compress_old
     echo ""
-
-    clean_old_logs
+    clean_old
     echo ""
-
-    limit_archived_logs
+    limit_archives
     echo ""
-
     show_stats
 }
 
 # Show usage
 show_usage() {
-    cat << EOF
-Minecraft Server Log Management Tool
+    cat <<EOF
+Minecraft Server Log Management
 
-Usage: $(basename "$0") [command] [options]
+Usage: $0 [command] [options]
 
 Commands:
     rotate                      Rotate current logs
     compress                    Compress old logs
     clean [days]               Clean logs older than N days (default: 30)
-    limit [count]              Keep only N most recent archives (default: 50)
-    maintenance                 Full maintenance (rotate + compress + clean)
-    stats                       Show log statistics
-    view [log] [lines]         View log file (default: latest.log, 50 lines)
-    search <pattern> [log]     Search in log file
-    help                        Show this help message
-
-Options:
-    --max-age <days>           Maximum log age in days (default: 30)
-    --max-archives <count>     Maximum archived logs to keep (default: 50)
-    --size-limit <mb>          Log size limit for rotation (default: 100)
+    limit [count]              Keep N most recent archives (default: 50)
+    maintenance                 Full maintenance
+    stats                       Show statistics
+    view [log] [lines]         View log (default: latest.log, 50 lines)
+    search <pattern> [log]     Search in log
+    help                        Show this help
 
 Examples:
-    $(basename "$0") rotate                    # Rotate all logs
-    $(basename "$0") clean 14                  # Clean logs older than 14 days
-    $(basename "$0") maintenance               # Full maintenance
-    $(basename "$0") stats                     # Show statistics
-    $(basename "$0") view latest.log 100       # View last 100 lines
-    $(basename "$0") search "error" latest.log # Search for errors
-
+    $0 rotate
+    $0 clean 14
+    $0 maintenance
+    $0 stats
+    $0 view latest.log 100
+    $0 search "error" latest.log
 EOF
 }
 
-# Main function
-main() {
-    local command="${1:-help}"
-
-    # Parse global options
-    shift || true
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --max-age)
-                MAX_LOG_AGE_DAYS="$2"
-                shift 2
-                ;;
-            --max-archives)
-                MAX_ARCHIVED_LOGS="$2"
-                shift 2
-                ;;
-            --size-limit)
-                LOG_SIZE_LIMIT_MB="$2"
-                shift 2
-                ;;
-            *)
-                break
-                ;;
-        esac
-    done
-
-    case "$command" in
-        rotate)
-            rotate_all_logs
-            ;;
-        compress)
-            compress_old_logs
-            ;;
-        clean)
-            MAX_LOG_AGE_DAYS="${1:-$MAX_LOG_AGE_DAYS}"
-            clean_old_logs
-            ;;
-        limit)
-            MAX_ARCHIVED_LOGS="${1:-$MAX_ARCHIVED_LOGS}"
-            limit_archived_logs
-            ;;
-        maintenance)
-            full_maintenance
-            ;;
-        stats)
-            show_stats
-            ;;
-        view)
-            view_log "${1:-latest.log}" "${2:-50}"
-            ;;
-        search)
-            if [ -z "${1:-}" ]; then
-                log_error "Please provide search pattern"
-                exit 1
-            fi
-            search_logs "$1" "${2:-latest.log}"
-            ;;
-        help|--help|-h)
-            show_usage
-            ;;
-        *)
-            log_error "Unknown command: $command"
-            show_usage
-            exit 1
-            ;;
-    esac
-}
-
-# Run main function
-main "$@"
+# Main
+case "${1:-help}" in
+    rotate) rotate_all;;
+    compress) compress_old;;
+    clean) MAX_LOG_AGE_DAYS="${2:-$MAX_LOG_AGE_DAYS}"; clean_old;;
+    limit) MAX_ARCHIVED_LOGS="${2:-$MAX_ARCHIVED_LOGS}"; limit_archives;;
+    maintenance) full_maintenance;;
+    stats) show_stats;;
+    view) view_log "${2:-latest.log}" "${3:-50}";;
+    search)
+        [[ -z "$2" ]] && { print_error "Provide search pattern"; exit 1; }
+        search_log "$2" "${3:-latest.log}";;
+    help|--help|-h) show_usage;;
+    *) print_error "Unknown command: $1"; show_usage; exit 1;;
+esac

--- a/tools/monitor.sh
+++ b/tools/monitor.sh
@@ -1,262 +1,124 @@
 #!/usr/bin/env bash
-# Minecraft Server Monitoring and Health Check Tool
-# Monitor server health, performance, and player activity
+# Simplified Minecraft server monitor
 
-# Source common functions (SCRIPT_DIR is auto-initialized)
 source "$(dirname -- "${BASH_SOURCE[0]}")/../lib/common.sh"
 
 init_strict_mode
 
 # Configuration
-SERVER_DIR="$SCRIPT_DIR"
-LOG_FILE="${SERVER_DIR}/logs/latest.log"
+LOG_FILE="${SCRIPT_DIR}/logs/latest.log"
 SERVER_PORT=25565
-CHECK_INTERVAL=60  # seconds
+CHECK_INTERVAL=60
 
-# Logging functions (wrapper around common.sh functions for consistency)
-log_info() { print_info "$*"; }
-log_success() { print_success "$*"; }
-log_warning() { print_info "$*"; }  # common.sh doesn't have print_warning
-log_error() { print_error "$*"; }
-
-# Check if server process is running
+# Check if process is running
 check_process() {
-    if pgrep -f "fabric-server-launch.jar" > /dev/null; then
-        return 0
-    fi
-    return 1
+    pgrep -f "fabric-server-launch.jar" > /dev/null || pgrep -f "server.jar" > /dev/null
 }
 
-# Check if server port is listening
+# Check if port is listening
 check_port() {
-    if command -v nc &> /dev/null; then
-        if nc -z localhost "$SERVER_PORT" 2>/dev/null; then
-            return 0
-        fi
-    elif command -v netstat &> /dev/null; then
-        if netstat -tuln | grep -q ":${SERVER_PORT} "; then
-            return 0
-        fi
-    elif command -v ss &> /dev/null; then
-        if ss -tuln | grep -q ":${SERVER_PORT} "; then
-            return 0
-        fi
+    if command -v nc &>/dev/null; then
+        nc -z localhost "$SERVER_PORT" 2>/dev/null
+    elif command -v ss &>/dev/null; then
+        ss -tuln | grep -q ":${SERVER_PORT} "
+    else
+        netstat -tuln 2>/dev/null | grep -q ":${SERVER_PORT} "
     fi
-    return 1
 }
 
 # Get server status
-get_server_status() {
-    local status="UNKNOWN"
-    local process_status="❌ Not Running"
-    local port_status="❌ Not Listening"
-
-    if check_process; then
-        process_status="✅ Running"
-        status="RUNNING"
-    fi
-
-    if check_port; then
-        port_status="✅ Listening"
-        if [ "$status" = "RUNNING" ]; then
-            status="ONLINE"
-        fi
-    fi
-
-    echo -e "${CYAN}Server Status:${NC}"
-    echo "  Process: $process_status"
-    echo "  Port $SERVER_PORT: $port_status"
-    echo "  Overall: $([ "$status" = "ONLINE" ] && echo -e "${GREEN}$status${NC}" || echo -e "${RED}$status${NC}")"
+get_status() {
+    print_header "Server Status"
+    check_process && echo "  Process: Running" || echo "  Process: Not Running"
+    check_port && echo "  Port $SERVER_PORT: Listening" || echo "  Port $SERVER_PORT: Not Listening"
     echo ""
 }
 
-# Get server memory usage
-get_memory_usage() {
-    if ! check_process; then
-        echo -e "${YELLOW}Server not running${NC}"
-        return 1
-    fi
-
+# Get memory usage
+get_memory() {
     local pid=$(pgrep -f "fabric-server-launch.jar" | head -1)
-    if [ -n "$pid" ]; then
-        local mem_kb=$(ps -p "$pid" -o rss= | awk '{print $1}')
-        local mem_mb=$((mem_kb / 1024))
-        local mem_gb=$(echo "scale=2; $mem_mb / 1024" | bc 2>/dev/null || echo "0")
+    [[ -z "$pid" ]] && { echo "Server not running"; return 1; }
 
-        echo -e "${CYAN}Memory Usage:${NC}"
-        echo "  Process ID: $pid"
-        echo "  Memory: ${mem_mb} MB (${mem_gb} GB)"
-        echo ""
-    fi
-}
-
-# Get CPU usage
-get_cpu_usage() {
-    if ! check_process; then
-        echo -e "${YELLOW}Server not running${NC}"
-        return 1
-    fi
-
-    local pid=$(pgrep -f "fabric-server-launch.jar" | head -1)
-    if [ -n "$pid" ] && command -v top &> /dev/null; then
-        local cpu=$(top -b -n 1 -p "$pid" 2>/dev/null | tail -1 | awk '{print $9}')
-        echo -e "${CYAN}CPU Usage:${NC}"
-        echo "  Process ID: $pid"
-        echo "  CPU: ${cpu}%"
-        echo ""
-    fi
+    print_header "Memory Usage"
+    local mem_kb=$(ps -p "$pid" -o rss= | awk '{print $1}')
+    local mem_mb=$((mem_kb / 1024))
+    echo "  PID: $pid"
+    echo "  Memory: ${mem_mb} MB"
+    echo ""
 }
 
 # Get disk usage
-get_disk_usage() {
-    echo -e "${CYAN}Disk Usage:${NC}"
-
-    if [ -d "${SERVER_DIR}/world" ]; then
-        local world_size=$(du -sh "${SERVER_DIR}/world" 2>/dev/null | cut -f1)
-        echo "  World: $world_size"
-    fi
-
-    if [ -d "${SERVER_DIR}/backups" ]; then
-        local backup_size=$(du -sh "${SERVER_DIR}/backups" 2>/dev/null | cut -f1)
-        echo "  Backups: $backup_size"
-    fi
-
-    if [ -d "${SERVER_DIR}/logs" ]; then
-        local logs_size=$(du -sh "${SERVER_DIR}/logs" 2>/dev/null | cut -f1)
-        echo "  Logs: $logs_size"
-    fi
-
-    local total_size=$(du -sh "${SERVER_DIR}" 2>/dev/null | cut -f1)
-    echo "  Total: $total_size"
+get_disk() {
+    print_header "Disk Usage"
+    [[ -d "${SCRIPT_DIR}/world" ]] && echo "  World: $(du -sh "${SCRIPT_DIR}/world" 2>/dev/null | cut -f1)"
+    [[ -d "${SCRIPT_DIR}/backups" ]] && echo "  Backups: $(du -sh "${SCRIPT_DIR}/backups" 2>/dev/null | cut -f1)"
+    [[ -d "${SCRIPT_DIR}/logs" ]] && echo "  Logs: $(du -sh "${SCRIPT_DIR}/logs" 2>/dev/null | cut -f1)"
+    echo "  Total: $(du -sh "${SCRIPT_DIR}" 2>/dev/null | cut -f1)"
     echo ""
 }
 
-# Get player count from logs
-get_player_count() {
-    if [ ! -f "$LOG_FILE" ]; then
-        echo -e "${YELLOW}Log file not found${NC}"
-        return 1
-    fi
+# Get player activity
+get_players() {
+    [[ ! -f "$LOG_FILE" ]] && { echo "Log file not found"; return 1; }
 
-    echo -e "${CYAN}Recent Player Activity:${NC}"
-
-    # Count unique players who joined in the last 100 log lines
-    local online_count=$(tail -n 100 "$LOG_FILE" 2>/dev/null | \
-        grep -oP '\[\d+:\d+:\d+\] \[Server thread/INFO\]: \K[^ ]+(?= joined the game)' | \
-        sort -u | wc -l)
-
-    local left_count=$(tail -n 100 "$LOG_FILE" 2>/dev/null | \
-        grep -oP '\[\d+:\d+:\d+\] \[Server thread/INFO\]: \K[^ ]+(?= left the game)' | \
-        sort -u | wc -l)
-
-    echo "  Players joined recently: $online_count"
-    echo "  Players left recently: $left_count"
-    echo ""
-
-    # Show last 5 player events
-    echo "  Last 5 player events:"
-    tail -n 200 "$LOG_FILE" 2>/dev/null | \
-        grep -E '(joined|left) the game' | \
-        tail -5 | \
-        sed 's/^/    /'
+    print_header "Recent Player Activity"
+    tail -200 "$LOG_FILE" 2>/dev/null | grep -E '(joined|left) the game' | tail -5 || echo "No recent activity"
     echo ""
 }
 
-# Check for errors in logs
+# Check for errors
 check_errors() {
-    if [ ! -f "$LOG_FILE" ]; then
-        echo -e "${YELLOW}Log file not found${NC}"
-        return 1
-    fi
+    [[ ! -f "$LOG_FILE" ]] && { echo "Log file not found"; return 1; }
 
-    echo -e "${CYAN}Recent Errors/Warnings:${NC}"
+    print_header "Recent Errors"
+    local errors=$(tail -100 "$LOG_FILE" 2>/dev/null | grep -ci 'ERROR\|SEVERE' || echo 0)
+    local warns=$(tail -100 "$LOG_FILE" 2>/dev/null | grep -ci 'WARN' || echo 0)
 
-    local error_count=$(tail -n 100 "$LOG_FILE" 2>/dev/null | grep -ci 'ERROR\|SEVERE' || echo "0")
-    local warn_count=$(tail -n 100 "$LOG_FILE" 2>/dev/null | grep -ci 'WARN' || echo "0")
+    echo "  Errors in last 100 lines: $errors"
+    echo "  Warnings in last 100 lines: $warns"
 
-    echo "  Errors in last 100 lines: $error_count"
-    echo "  Warnings in last 100 lines: $warn_count"
-
-    if [ "$error_count" -gt 0 ]; then
+    [[ $errors -gt 0 ]] && {
         echo ""
         echo "  Last 3 errors:"
-        tail -n 100 "$LOG_FILE" 2>/dev/null | \
-            grep -i 'ERROR\|SEVERE' | \
-            tail -3 | \
-            sed 's/^/    /'
-    fi
+        tail -100 "$LOG_FILE" 2>/dev/null | grep -i 'ERROR\|SEVERE' | tail -3 | sed 's/^/    /'
+    }
     echo ""
 }
 
-# Get server TPS (Ticks Per Second) if available
-get_tps() {
-    if [ ! -f "$LOG_FILE" ]; then
-        return 1
-    fi
-
-    echo -e "${CYAN}Performance Metrics:${NC}"
-
-    # Look for TPS information in logs (if Spark or similar is installed)
-    local tps_line=$(tail -n 50 "$LOG_FILE" 2>/dev/null | grep -i "TPS" | tail -1)
-    if [ -n "$tps_line" ]; then
-        echo "  $tps_line"
-    else
-        echo "  TPS info not available (install Spark for detailed metrics)"
-    fi
-
-    # Look for tick duration
-    local tick_line=$(tail -n 50 "$LOG_FILE" 2>/dev/null | grep -i "Running.*behind\|tick" | tail -1)
-    if [ -n "$tick_line" ]; then
-        echo "  $tick_line"
-    fi
-    echo ""
-}
-
-# Get server uptime
+# Get uptime
 get_uptime() {
-    if ! check_process; then
-        echo -e "${YELLOW}Server not running${NC}"
-        return 1
-    fi
-
     local pid=$(pgrep -f "fabric-server-launch.jar" | head -1)
-    if [ -n "$pid" ]; then
-        local uptime_seconds=$(ps -p "$pid" -o etimes= | tr -d ' ')
-        local days=$((uptime_seconds / 86400))
-        local hours=$(((uptime_seconds % 86400) / 3600))
-        local minutes=$(((uptime_seconds % 3600) / 60))
+    [[ -z "$pid" ]] && { echo "Server not running"; return 1; }
 
-        echo -e "${CYAN}Server Uptime:${NC}"
-        echo "  ${days}d ${hours}h ${minutes}m"
-        echo ""
-    fi
+    print_header "Server Uptime"
+    local uptime_sec=$(ps -p "$pid" -o etimes= | tr -d ' ')
+    local days=$((uptime_sec / 86400))
+    local hours=$(((uptime_sec % 86400) / 3600))
+    local mins=$(((uptime_sec % 3600) / 60))
+    echo "  ${days}d ${hours}h ${mins}m"
+    echo ""
 }
 
-# Comprehensive status report
+# Show comprehensive status
 show_status() {
     echo ""
-    echo "═══════════════════════════════════════════════════════════"
-    echo "           Minecraft Server Health Report"
-    echo "           $(date '+%Y-%m-%d %H:%M:%S')"
-    echo "═══════════════════════════════════════════════════════════"
+    echo "════════════════════════════════════════════════════════"
+    echo "      Minecraft Server Monitor - $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "════════════════════════════════════════════════════════"
     echo ""
-
-    get_server_status
+    get_status
     get_uptime
-    get_memory_usage
-    get_cpu_usage
-    get_disk_usage
-    get_player_count
+    get_memory
+    get_disk
+    get_players
     check_errors
-    get_tps
-
-    echo "═══════════════════════════════════════════════════════════"
+    echo "════════════════════════════════════════════════════════"
 }
 
-# Watch mode - continuous monitoring
+# Watch mode
 watch_mode() {
-    echo "Starting continuous monitoring (Ctrl+C to stop)..."
-    echo "Update interval: ${CHECK_INTERVAL} seconds"
+    echo "Starting monitor (Ctrl+C to stop)"
+    echo "Update interval: ${CHECK_INTERVAL}s"
     echo ""
 
     while true; do
@@ -266,112 +128,55 @@ watch_mode() {
     done
 }
 
-# Alert mode - check for critical issues
+# Alert mode
 alert_mode() {
-    log_info "Running health check..."
-
     local issues=0
 
-    # Check if server is running
-    if ! check_process; then
-        log_error "Server process is not running!"
-        ((issues++))
+    check_process || { print_error "Process not running"; ((issues++)); }
+    check_port || { print_error "Port not listening"; ((issues++)); }
+
+    if [[ -f "$LOG_FILE" ]]; then
+        local errors=$(tail -20 "$LOG_FILE" 2>/dev/null | grep -ci 'ERROR\|SEVERE' || echo 0)
+        [[ $errors -gt 5 ]] && { print_error "High error rate: $errors errors"; ((issues++)); }
     fi
 
-    # Check if port is listening
-    if ! check_port; then
-        log_error "Server is not listening on port $SERVER_PORT!"
-        ((issues++))
-    fi
+    local disk=$(df -h "${SCRIPT_DIR}" | tail -1 | awk '{print $5}' | sed 's/%//')
+    [[ $disk -gt 90 ]] && { print_error "Disk usage critical: ${disk}%"; ((issues++)); }
 
-    # Check for errors in logs
-    if [ -f "$LOG_FILE" ]; then
-        local recent_errors=$(tail -n 20 "$LOG_FILE" 2>/dev/null | grep -ci 'ERROR\|SEVERE' || echo "0")
-        if [ "$recent_errors" -gt 5 ]; then
-            log_error "High error rate detected: $recent_errors errors in last 20 log lines!"
-            ((issues++))
-        fi
-    fi
-
-    # Check disk space
-    local disk_usage=$(df -h "${SERVER_DIR}" | tail -1 | awk '{print $5}' | sed 's/%//')
-    if [ "$disk_usage" -gt 90 ]; then
-        log_error "Disk usage is critical: ${disk_usage}%!"
-        ((issues++))
-    elif [ "$disk_usage" -gt 80 ]; then
-        log_warning "Disk usage is high: ${disk_usage}%"
-    fi
-
-    if [ "$issues" -eq 0 ]; then
-        log_success "All health checks passed!"
-        return 0
-    else
-        log_error "Health check failed with $issues issue(s)"
-        return 1
-    fi
+    [[ $issues -eq 0 ]] && { print_success "All checks passed"; return 0; }
+    print_error "Health check failed: $issues issue(s)"
+    return 1
 }
 
 # Show usage
 show_usage() {
-    cat << EOF
-Minecraft Server Monitoring Tool
+    cat <<EOF
+Minecraft Server Monitor
 
-Usage: $(basename "$0") [command] [options]
+Usage: $0 [command]
 
 Commands:
-    status          Show comprehensive server status (default)
-    watch           Continuous monitoring mode
-    alert           Run health check and alert on issues
-    players         Show player activity
-    errors          Show recent errors
-    help            Show this help message
-
-Options:
-    --interval <seconds>    Update interval for watch mode (default: 60)
+    status      Show server status (default)
+    watch       Continuous monitoring
+    alert       Run health check
+    players     Show player activity
+    errors      Show recent errors
+    help        Show this help
 
 Examples:
-    $(basename "$0")                    # Show status
-    $(basename "$0") status             # Show detailed status
-    $(basename "$0") watch              # Watch mode
-    $(basename "$0") alert              # Health check
-    $(basename "$0") players            # Show players
-
+    $0              # Show status
+    $0 watch        # Watch mode
+    $0 alert        # Health check
 EOF
 }
 
-# Main function
-main() {
-    local command="${1:-status}"
-
-    case "$command" in
-        status)
-            show_status
-            ;;
-        watch)
-            if [ "${2:-}" = "--interval" ]; then
-                CHECK_INTERVAL="${3:-60}"
-            fi
-            watch_mode
-            ;;
-        alert)
-            alert_mode
-            ;;
-        players)
-            get_player_count
-            ;;
-        errors)
-            check_errors
-            ;;
-        help|--help|-h)
-            show_usage
-            ;;
-        *)
-            log_error "Unknown command: $command"
-            show_usage
-            exit 1
-            ;;
-    esac
-}
-
-# Run main function
-main "$@"
+# Main
+case "${1:-status}" in
+    status) show_status;;
+    watch) watch_mode;;
+    alert) alert_mode;;
+    players) get_players;;
+    errors) check_errors;;
+    help|--help|-h) show_usage;;
+    *) print_error "Unknown command: $1"; show_usage; exit 1;;
+esac

--- a/tools/watchdog.sh
+++ b/tools/watchdog.sh
@@ -1,391 +1,190 @@
 #!/usr/bin/env bash
-# Minecraft Server Watchdog - Automatic Restart and Crash Recovery
-# Monitors server health and automatically restarts on crashes
+# Simplified Minecraft server watchdog
 
-# Source common functions (SCRIPT_DIR is auto-initialized)
 source "$(dirname -- "${BASH_SOURCE[0]}")/../lib/common.sh"
 
 init_strict_mode
 
 # Configuration
-SERVER_DIR="$SCRIPT_DIR"
-SERVER_START_SCRIPT="${SERVER_DIR}/scripts/server-start.sh"
-CHECK_INTERVAL=30  # seconds
+SERVER_START_SCRIPT="${SCRIPT_DIR}/scripts/server-start.sh"
+CHECK_INTERVAL=30
 MAX_RESTART_ATTEMPTS=3
-RESTART_COOLDOWN=300  # 5 minutes
-PID_FILE="${SERVER_DIR}/.server.pid"
-LOG_FILE="${SERVER_DIR}/logs/watchdog.log"
+RESTART_COOLDOWN=300
+LOG_FILE="${SCRIPT_DIR}/logs/watchdog.log"
 
-# State tracking
+# State
 RESTART_COUNT=0
 LAST_RESTART_TIME=0
 
-# Logging functions with file output
-log_info() {
-    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] [INFO] $*"
-    print_info "$msg"
-    echo "$msg" >> "$LOG_FILE"
+# Logging
+mkdir -p "$(dirname "$LOG_FILE")"
+log() {
+    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    echo "$msg" | tee -a "$LOG_FILE"
 }
 
-log_success() {
-    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] [SUCCESS] $*"
-    print_success "$msg"
-    echo "$msg" >> "$LOG_FILE"
-}
-
-log_warning() {
-    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] [WARNING] $*"
-    print_info "$msg"
-    echo "$msg" >> "$LOG_FILE"
-}
-
-log_error() {
-    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] [ERROR] $*"
-    print_error "$msg"
-    echo "$msg" >> "$LOG_FILE"
-}
-
-# Initialize log directory
-init_logging() {
-    mkdir -p "$(dirname "$LOG_FILE")"
-    touch "$LOG_FILE"
-}
-
-# Check if server process is running
+# Check if server is running
 is_server_running() {
-    if [ -f "$PID_FILE" ]; then
-        local pid=$(cat "$PID_FILE")
-        if ps -p "$pid" > /dev/null 2>&1; then
-            return 0
-        fi
+    pgrep -f "fabric-server-launch.jar" > /dev/null || pgrep -f "server.jar" > /dev/null
+}
+
+# Can we restart?
+can_restart() {
+    local current_time=$(date +%s)
+    local time_since=$((current_time - LAST_RESTART_TIME))
+
+    [[ $time_since -lt $RESTART_COOLDOWN ]] && {
+        log "Too soon to restart. Wait $((RESTART_COOLDOWN - time_since))s"
+        return 1
+    }
+
+    [[ $RESTART_COUNT -ge $MAX_RESTART_ATTEMPTS ]] && {
+        log "Max restart attempts ($MAX_RESTART_ATTEMPTS) reached"
+        return 1
+    }
+
+    return 0
+}
+
+# Start server
+start_server() {
+    log "Starting server..."
+    [[ ! -x "$SERVER_START_SCRIPT" ]] && { log "Start script not found"; return 1; }
+
+    cd "$SCRIPT_DIR"
+
+    if command -v screen &>/dev/null; then
+        screen -dmS minecraft bash -c "cd '$SCRIPT_DIR' && '$SERVER_START_SCRIPT'"
+    elif command -v tmux &>/dev/null; then
+        tmux new-session -d -s minecraft "cd '$SCRIPT_DIR' && '$SERVER_START_SCRIPT'"
+    else
+        nohup "$SERVER_START_SCRIPT" > "${SCRIPT_DIR}/logs/server.log" 2>&1 &
     fi
 
-    # Fallback: check for process by name
-    if pgrep -f "fabric-server-launch.jar" > /dev/null; then
+    sleep 30
+    is_server_running && {
+        log "Server started successfully"
+        LAST_RESTART_TIME=$(date +%s)
+        ((RESTART_COUNT++))
         return 0
-    fi
+    }
 
+    log "Server failed to start"
     return 1
 }
 
-# Get current timestamp
-get_timestamp() {
-    date +%s
-}
-
-# Check if enough time has passed since last restart
-can_restart() {
-    local current_time=$(get_timestamp)
-    local time_since_restart=$((current_time - LAST_RESTART_TIME))
-
-    if [ "$time_since_restart" -lt "$RESTART_COOLDOWN" ]; then
-        log_warning "Too soon to restart. Waiting $((RESTART_COOLDOWN - time_since_restart)) more seconds..."
-        return 1
-    fi
-
-    if [ "$RESTART_COUNT" -ge "$MAX_RESTART_ATTEMPTS" ]; then
-        log_error "Maximum restart attempts ($MAX_RESTART_ATTEMPTS) reached. Manual intervention required."
-        return 1
-    fi
-
-    return 0
-}
-
-# Create backup before restart
-create_emergency_backup() {
-    log_info "Creating emergency backup before restart..."
-
-    if [ -x "${SCRIPT_DIR}/backup.sh" ]; then
-        "${SCRIPT_DIR}/backup.sh" backup world --max-backups 5 || {
-            log_warning "Emergency backup failed, continuing with restart..."
-        }
-    else
-        log_warning "Backup script not found, skipping emergency backup"
-    fi
-}
-
-# Start the server
-start_server() {
-    log_info "Starting Minecraft server..."
-
-    if [ ! -x "$SERVER_START_SCRIPT" ]; then
-        log_error "Server start script not found or not executable: $SERVER_START_SCRIPT"
-        return 1
-    fi
-
-    cd "$SERVER_DIR"
-
-    # Start server in screen session if available
-    if command -v screen &> /dev/null; then
-        screen -dmS minecraft bash -c "cd '$SERVER_DIR' && '$SERVER_START_SCRIPT'"
-        log_success "Server started in screen session 'minecraft'"
-    # Or use tmux if available
-    elif command -v tmux &> /dev/null; then
-        tmux new-session -d -s minecraft "cd '$SERVER_DIR' && '$SERVER_START_SCRIPT'"
-        log_success "Server started in tmux session 'minecraft'"
-    else
-        # Start in background
-        nohup "$SERVER_START_SCRIPT" > "${SERVER_DIR}/logs/server.log" 2>&1 &
-        local pid=$!
-        echo "$pid" > "$PID_FILE"
-        log_success "Server started with PID: $pid"
-    fi
-
-    # Wait for server to initialize
-    log_info "Waiting for server to start..."
-    sleep 30
-
-    if is_server_running; then
-        log_success "Server started successfully"
-        LAST_RESTART_TIME=$(get_timestamp)
-        ((RESTART_COUNT++))
-        return 0
-    else
-        log_error "Server failed to start"
-        return 1
-    fi
-}
-
-# Stop the server gracefully
+# Stop server
 stop_server() {
-    log_info "Stopping server gracefully..."
+    log "Stopping server..."
 
-    # Try sending stop command to screen/tmux session
+    # Try graceful stop via screen/tmux
     if screen -list 2>/dev/null | grep -q "minecraft"; then
         screen -S minecraft -X stuff "stop^M"
-        log_info "Stop command sent to screen session"
     elif tmux list-sessions 2>/dev/null | grep -q "minecraft"; then
         tmux send-keys -t minecraft "stop" Enter
-        log_info "Stop command sent to tmux session"
     fi
 
-    # Wait for graceful shutdown
-    local wait_time=0
-    while is_server_running && [ $wait_time -lt 60 ]; do
+    # Wait for shutdown
+    local wait=0
+    while is_server_running && [[ $wait -lt 60 ]]; do
         sleep 5
-        ((wait_time += 5))
-        log_info "Waiting for server to stop... (${wait_time}s)"
+        ((wait += 5))
     done
 
-    # Force kill if still running
-    if is_server_running; then
-        log_warning "Server did not stop gracefully, force killing..."
-        pkill -9 -f "fabric-server-launch.jar" || true
-        sleep 5
-    fi
+    # Force kill if needed
+    is_server_running && pkill -9 -f "fabric-server-launch.jar"
 
-    if ! is_server_running; then
-        log_success "Server stopped"
-        return 0
-    else
-        log_error "Failed to stop server"
-        return 1
-    fi
+    log "Server stopped"
 }
 
-# Restart the server
+# Restart server
 restart_server() {
-    log_info "Initiating server restart..."
+    log "Restarting server..."
+    can_restart || return 1
 
-    if ! can_restart; then
-        return 1
-    fi
-
-    # Create emergency backup
-    create_emergency_backup
-
-    # Stop server if running
-    if is_server_running; then
-        stop_server || {
-            log_error "Failed to stop server, aborting restart"
-            return 1
-        }
-    fi
-
-    # Start server
+    is_server_running && stop_server
     start_server
 }
 
-# Check server health
+# Check health
 check_health() {
-    if ! is_server_running; then
-        log_error "Server is not running!"
-        return 1
-    fi
+    is_server_running || { log "Server not running"; return 1; }
 
-    # Check if server is responding (check log activity)
-    local log_file="${SERVER_DIR}/logs/latest.log"
-    if [ -f "$log_file" ]; then
-        local last_log_time=$(stat -c %Y "$log_file" 2>/dev/null || echo "0")
-        local current_time=$(get_timestamp)
-        local time_since_log=$((current_time - last_log_time))
+    # Check log activity
+    local log_file="${SCRIPT_DIR}/logs/latest.log"
+    if [[ -f "$log_file" ]]; then
+        local last_log=$(stat -c %Y "$log_file" 2>/dev/null || echo 0)
+        local now=$(date +%s)
+        local idle=$((now - last_log))
 
-        # If no log activity for 5 minutes, server might be frozen
-        if [ "$time_since_log" -gt 300 ]; then
-            log_warning "No log activity for ${time_since_log} seconds - server may be frozen"
-            return 1
-        fi
+        # No activity for 5 minutes = frozen
+        [[ $idle -gt 300 ]] && { log "No log activity for ${idle}s"; return 1; }
     fi
 
     return 0
 }
 
-# Monitor mode - continuous monitoring with auto-restart
+# Monitor mode
 monitor_mode() {
-    log_info "Starting watchdog monitor (Ctrl+C to stop)"
-    log_info "Check interval: ${CHECK_INTERVAL}s, Max restart attempts: ${MAX_RESTART_ATTEMPTS}"
+    log "Watchdog started (interval: ${CHECK_INTERVAL}s, max attempts: ${MAX_RESTART_ATTEMPTS})"
 
     while true; do
         if ! check_health; then
-            log_error "Health check failed - attempting restart"
-
+            log "Health check failed - restarting"
             if restart_server; then
-                log_success "Server restarted successfully"
-
-                # Reset restart count after successful cooldown period
+                log "Restart successful"
                 sleep "$RESTART_COOLDOWN"
                 RESTART_COUNT=0
-                log_info "Restart counter reset"
             else
-                log_error "Failed to restart server"
-
-                # If we've hit max attempts, wait longer before trying again
-                if [ "$RESTART_COUNT" -ge "$MAX_RESTART_ATTEMPTS" ]; then
-                    log_error "Maximum restart attempts reached. Waiting 30 minutes before retry..."
+                log "Restart failed"
+                [[ $RESTART_COUNT -ge $MAX_RESTART_ATTEMPTS ]] && {
+                    log "Waiting 30 minutes before retry..."
                     sleep 1800
                     RESTART_COUNT=0
                     LAST_RESTART_TIME=0
-                fi
+                }
             fi
         fi
-
         sleep "$CHECK_INTERVAL"
     done
 }
 
-# Scheduled restart (with warning)
-scheduled_restart() {
-    local warning_time="${1:-300}"  # 5 minutes default
-
-    log_info "Scheduled restart initiated. Warning time: ${warning_time}s"
-
-    # Send warnings to players
-    if screen -list 2>/dev/null | grep -q "minecraft"; then
-        for time in 300 180 120 60 30 10; do
-            if [ "$time" -le "$warning_time" ] && [ "$warning_time" -gt 0 ]; then
-                screen -S minecraft -X stuff "say Server restart in ${time} seconds!^M"
-                log_info "Sent ${time}s warning to players"
-
-                if [ "$time" -eq "$warning_time" ]; then
-                    sleep "$warning_time"
-                    warning_time=0
-                else
-                    sleep $((warning_time - time + 10))
-                    warning_time=$((time - 10))
-                fi
-            fi
-        done
-    fi
-
-    # Perform restart
-    restart_server
-}
-
 # Show usage
 show_usage() {
-    cat << EOF
-Minecraft Server Watchdog - Automatic Restart and Crash Recovery
+    cat <<EOF
+Minecraft Server Watchdog
 
-Usage: $(basename "$0") [command] [options]
+Usage: $0 [command]
 
 Commands:
-    monitor                Start watchdog monitor (auto-restart on crash)
-    restart [warning_time] Schedule server restart with optional warning (seconds)
-    start                  Start the server
-    stop                   Stop the server
-    status                 Check if server is running
-    help                   Show this help message
-
-Options:
-    --interval <seconds>   Check interval for monitor mode (default: 30)
-    --max-attempts <num>   Max restart attempts (default: 3)
-    --cooldown <seconds>   Time between restart attempts (default: 300)
+    monitor     Start watchdog (auto-restart on crash)
+    restart     Restart server immediately
+    start       Start server
+    stop        Stop server
+    status      Check if running
+    help        Show this help
 
 Examples:
-    $(basename "$0") monitor           # Start watchdog
-    $(basename "$0") restart 600       # Restart with 10min warning
-    $(basename "$0") restart 0         # Restart immediately
-    $(basename "$0") start             # Start server
-    $(basename "$0") stop              # Stop server
-
-Note: Monitor mode should be run in a screen/tmux session or as a service
-
+    $0 monitor      # Start watchdog
+    $0 restart      # Restart now
+    $0 status       # Check status
 EOF
 }
 
-# Main function
-main() {
-    init_logging
-
-    local command="${1:-help}"
-
-    # Parse global options
-    shift || true
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --interval)
-                CHECK_INTERVAL="$2"
-                shift 2
-                ;;
-            --max-attempts)
-                MAX_RESTART_ATTEMPTS="$2"
-                shift 2
-                ;;
-            --cooldown)
-                RESTART_COOLDOWN="$2"
-                shift 2
-                ;;
-            *)
-                break
-                ;;
-        esac
-    done
-
-    case "$command" in
-        monitor)
-            monitor_mode
-            ;;
-        restart)
-            scheduled_restart "${1:-300}"
-            ;;
-        start)
-            start_server
-            ;;
-        stop)
-            stop_server
-            ;;
-        status)
-            if is_server_running; then
-                log_success "Server is running"
-                exit 0
-            else
-                log_error "Server is not running"
-                exit 1
-            fi
-            ;;
-        help|--help|-h)
-            show_usage
-            ;;
-        *)
-            log_error "Unknown command: $command"
-            show_usage
+# Main
+case "${1:-help}" in
+    monitor) monitor_mode;;
+    restart) restart_server;;
+    start) start_server;;
+    stop) stop_server;;
+    status)
+        if is_server_running; then
+            log "Server is running"
+            exit 0
+        else
+            log "Server is not running"
             exit 1
-            ;;
-    esac
-}
-
-# Handle Ctrl+C gracefully
-trap 'log_info "Watchdog stopped by user"; exit 0' INT TERM
-
-# Run main function
-main "$@"
+        fi;;
+    help|--help|-h) show_usage;;
+    *) log "Unknown command: $1"; show_usage; exit 1;;
+esac


### PR DESCRIPTION
Simplified all shell scripts by removing over-engineering and reducing complexity:

- server-start.sh (205→71 lines): Removed complex JVM configs, multi-terminal support, system optimizations
- prepare.sh (62→40 lines): Removed package installation, focused on AppCDS generation
- mcdl.sh (58→31 lines): Streamlined Fabric downloader, removed caching complexity
- mod-updates.sh (412→146 lines): Removed profile system, kept core update workflows
- tools/backup.sh (324→136 lines): Removed verbose wrappers, simplified notifications
- tools/watchdog.sh (392→191 lines): Streamlined monitoring, removed emergency backups
- tools/monitor.sh (378→183 lines): Simplified checks, removed verbose statistics
- tools/logrotate.sh (415→241 lines): Removed complex option parsing, simplified rotation

Total reduction: ~2246 lines → ~1039 lines (54% reduction)