### PR TITLE
security(ci): pin GitHub Actions to SHA, restrict permissions

### DIFF
--- a/.github/workflows/config-format.yml
+++ b/.github/workflows/config-format.yml
@@ -28,6 +28,11 @@ on:
           - check
           - format
           - minify
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   format-check:
     name: Check Config Formatting
@@ -37,7 +42,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
       - name: Install dependencies
@@ -94,7 +99,7 @@ jobs:
           fi
       - name: Comment on PR (if formatting needed)
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             github.rest.issues.createComment({
@@ -108,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
       - name: Validate all JSON files
@@ -138,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Install yq
         run: |
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64

--- a/.github/workflows/image-optimization.yml
+++ b/.github/workflows/image-optimization.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: false
         type: boolean
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   optimize-images:
     name: Optimize Image Files
@@ -37,7 +42,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           fetch-depth: 0
       - name: Install image optimization tools
@@ -267,7 +272,7 @@ jobs:
           fi
       - name: Comment on PR (if images were optimized)
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const pngOptimized = parseInt('${{ steps.optimize-png.outputs.png_optimized }}');

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -9,6 +9,8 @@ on:
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   megalinter:
     name: MegaLinter
@@ -19,13 +21,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
       - name: MegaLinter
         id: ml
-        uses: oxsecurity/megalinter@v9
+        uses: oxsecurity/megalinter@ff177bfabd9088ff3ccaa7bc68f8ca3fd075ba5c # v9.0.0
         env:
           APPLY_FIXES: all
           APPLY_FIXES_EVENT: all
@@ -39,7 +41,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
       - name: Archive reports
         if: success() || failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: MegaLinter reports
           path: |
@@ -50,7 +52,7 @@ jobs:
         if: >
           steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
 
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "[MegaLinter] Apply linter fixes"
@@ -62,7 +64,7 @@ jobs:
         if: >
           steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
 
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/packsquash.yml
+++ b/.github/workflows/packsquash.yml
@@ -3,7 +3,8 @@ on: workflow_dispatch
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
   cancel-in-progress: true
-
+permissions:
+  contents: read
 jobs:
   packsquash:
     name: Optimize resource pack
@@ -11,12 +12,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
         with:
           token: ${{ secrets.PAT || github.token }}
           fetch-depth: 0
       - name: Run PackSquash
-        uses: ComunidadAylas/PackSquash-action@v4
+        uses: ComunidadAylas/PackSquash-action@a9128decf6503efc143586d8eebbf52a861fcb6e # v4.0.3
         with:
           packsquash_version: latest
       - name: Commit optimized pack
@@ -26,7 +27,7 @@ jobs:
           git add .
           git diff --staged --quiet || git commit -m "chore: optimize resource pack with PackSquash"
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # v1.0.0
         with:
           github_token: ${{ secrets.PAT || github.token }}
           branch: ${{ github.head_ref || github.ref || github.run_id }}

--- a/scripts/server-start.sh
+++ b/scripts/server-start.sh
@@ -41,6 +41,7 @@ get_cpu_cores() { nproc 2>/dev/null || echo 4; }
 
 # Output formatting helpers
 print_header() { printf '\033[0;34m==>\033[0m %s\n' "$1"; }
+print_success() { printf '\033[0;32m✓\033[0m %s\n' "$1"; }
 print_error() { printf '\033[0;31m✗\033[0m %s\n' "$1" >&2; }
 print_info() { printf '\033[1;33m→\033[0m %s\n' "$1"; }
 
@@ -67,6 +68,7 @@ print_info "Memory: ${XMS} - ${XMX} | CPU Cores: ${CPU_CORES}"
 
 # JDK Detection
 JAVA_CMD="java"
+JAVA_TYPE=""
 if has_command archlinux-java; then
   sudo archlinux-java fix 2>/dev/null || :
   SEL_JAVA="$(archlinux-java get 2>/dev/null)"

--- a/tools/backup.sh
+++ b/tools/backup.sh
@@ -354,26 +354,14 @@ case "${1:-backup}" in
   list) list_backups ;;
   restore) restore_backup "$2" ;;
   cleanup) cleanup_old_backups ;;
+  snapshot) create_btrfs_snapshot "${2:-}" "${3:-}" ;;
+  snapshot-list) list_btrfs_snapshots ;;
+  snapshot-restore) restore_btrfs_snapshot "$2" "${3:-}" ;;
+  snapshot-delete) delete_btrfs_snapshot "$2" ;;
   help | --help | -h) show_usage ;;
   *)
     print_error "Unknown command: $1"
     show_usage
     exit 1
     ;;
-  esac
-  cleanup_old_backups
-  ;;
-list) list_backups ;;
-restore) restore_backup "$2" ;;
-cleanup) cleanup_old_backups ;;
-snapshot) create_btrfs_snapshot "${2:-}" "${3:-}" ;;
-snapshot-list) list_btrfs_snapshots ;;
-snapshot-restore) restore_btrfs_snapshot "$2" "${3:-}" ;;
-snapshot-delete) delete_btrfs_snapshot "$2" ;;
-help | --help | -h) show_usage ;;
-*)
-  print_error "Unknown command: $1"
-  show_usage
-  exit 1
-  ;;
 esac


### PR DESCRIPTION
- Pin all GitHub Actions to full commit SHAs for immutability:
  - actions/checkout@v6 → 1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
  - actions/upload-artifact@v5 → 330a01c490aca151604b8cf639adc76d48f6c5d4
  - actions/github-script@v8 → ed597411d8f924073f98dfc5c65a23a2325f34cd
  - oxsecurity/megalinter@v9 → ff177bfabd9088ff3ccaa7bc68f8ca3fd075ba5c
  - peter-evans/create-pull-request@v7 → 22a9089034f40e5a961c8808d113e2c98fb63676
  - peter-evans/create-or-update-comment@v5 → e8674b075228eee787fea43ef493e45ece1004c9
  - ComunidadAylas/PackSquash-action@v4 → a9128decf6503efc143586d8eebbf52a861fcb6e
  - ad-m/github-push-action@master → v1.0.0 SHA (critical fix)
- Add top-level `permissions: contents: read` to all workflows
- Add concurrency groups to image-optimization and config-format
- Fix backup.sh duplicate case block syntax error
- Fix server-start.sh: add missing print_success function, init JAVA_TYPE