### PR TITLE
Merge mcctl integration from Kraftland/mcctl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,16 @@
 - **Install/Update Fabric**: `./tools/mod-updates.sh install-fabric [version]`
 - **Update Mods**: `./tools/mod-updates.sh ferium`
 
-### Paper/Spigot Server Management (NEW)
+### Paper/Spigot Server Management
 
 - **Build Paper**: `./tools/mcctl.sh build-paper [version]`
 - **Build Spigot**: `./tools/mcctl.sh build-spigot [version]`
 - **Update Plugin**: `./tools/mcctl.sh update <plugin>`
 - **Update All Plugins**: `./tools/mcctl.sh update-all`
 - **Initialize Server**: `./tools/mcctl.sh init`
+- **Accept EULA**: `./tools/mcctl.sh accept-eula`
+
+**Supported Plugins**: viaversion, viabackwards, multilogin, floodgate, geyser, protocollib, vault, luckperms, griefprevention, freedomchat, deluxemenus, noencryption, craftgui, globalmarket
 
 ### Backup & Snapshots
 
@@ -92,11 +95,15 @@
 
 ## mcctl Integration
 
-This repository includes an integrated version of [Kraftland/mcctl](https://github.com/Kraftland/mcctl) for Paper/Spigot server management. The tool has been modernized to follow this repository's code standards:
+This repository includes an integrated version of [Kraftland/mcctl](https://github.com/Kraftland/mcctl) (v2.1.0-integrated, based on upstream v1.6-stable) for Paper/Spigot server management. The tool has been modernized to follow this repository's code standards:
 
 - Modern bash with strict mode (`set -euo pipefail`)
 - Consistent code style (2-space indent, snake_case)
 - Modular design with clear separation of concerns
 - Compatible with existing Fabric-focused tooling
+- Extended plugin support (14 plugins including ViaVersion, Geyser, LuckPerms, and more)
+- Proper GPL-3.0 license attribution (see CREDITS.md)
 
 Use `./tools/mcctl.sh help` for Paper/Spigot commands.
+
+**Original Author**: Kimiblock | **License**: GPL-3.0

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,36 @@
+# Credits and Attribution
+
+## mcctl Integration
+
+This repository includes an integrated and modernized version of **mcctl** (Minecraft Server Control), originally created by **Kimiblock**.
+
+- **Original Project**: [Kraftland/mcctl](https://github.com/Kraftland/mcctl)
+- **Original Author**: Kimiblock
+- **Upstream Version**: v1.6-stable
+- **License**: GPL-3.0
+- **Integration Location**: `tools/mcctl.sh`
+
+### Changes in Integration
+
+The integrated version has been modernized to follow this repository's code standards:
+
+- **Modern Bash**: Uses strict mode (`set -euo pipefail`) and bash 5.0+ features
+- **Modular Design**: Integrates with `lib/common.sh` for shared functionality
+- **Code Style**: Follows repository standards (2-space indent, snake_case variables)
+- **Extended Features**: Added support for additional plugins while maintaining upstream compatibility
+- **Documentation**: Integrated into repository's documentation system
+
+### Acknowledgments
+
+We are grateful to Kimiblock and the Kraftland project for creating and maintaining mcctl. Their work has significantly enhanced the Paper/Spigot server management capabilities of this repository.
+
+## Other Components
+
+- **Playit.gg**: Proxy and tunneling support
+- **Infrarust**: Alternative proxy solution
+- **lazymc**: Auto sleep/wake functionality for Minecraft servers
+- **GeyserMC**: Bedrock/Java interoperability (Geyser and Floodgate)
+- **Paper Project**: Paper server implementation
+- **Spigot**: Spigot server implementation and BuildTools
+
+All third-party components are subject to their respective licenses.

--- a/tools/mcctl.sh
+++ b/tools/mcctl.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # mcctl.sh: Paper/Spigot server management tool
 # Integrated from: https://github.com/Kraftland/mcctl
+#
+# Original Author: Kimiblock (https://github.com/Kimiblock/mcctl)
+# Original Version: v1.6-stable
+# License: GPL-3.0 (inherited from upstream)
+#
+# This is a modernized integration that follows the MC-Server repository's
+# code standards while preserving the core functionality of the original mcctl.
 
 # Source common library
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -8,7 +15,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${SCRIPT_DIR}/lib/common.sh"
 
 # Version
-MCCTL_VERSION="2.0.0-integrated"
+MCCTL_VERSION="2.1.0-integrated"
 
 # Get latest git tag from repository
 get_latest_tag(){
@@ -73,6 +80,31 @@ get_url(){
       ;;
     griefprevention)
       url="https://github.com/TechFortress/GriefPrevention/releases/latest/download/GriefPrevention.jar"
+      ;;
+    freedomchat)
+      url="https://cdn.modrinth.com/data/MubyTbnA/versions/qGaisS0d/FreedomChat-1.3.1.jar"
+      ;;
+    deluxemenus)
+      url="https://ci.extendedclip.com/job/DeluxeMenus/lastStableBuild/artifact/build/libs/DeluxeMenus-1.13.7-DEV-152.jar"
+      ;;
+    noencryption)
+      local tag
+      tag=$(get_latest_tag "https://github.com/Doclic/NoEncryption.git" || echo "1.0.0")
+      url="https://github.com/Doclic/NoEncryption/releases/latest/download/NoEncryption-${tag}.jar"
+      ;;
+    craftgui)
+      local tag
+      tag=$(get_latest_tag "https://github.com/Fireflyest/CraftGUI.git" || echo "1.0.0")
+      local version_num
+      version_num=$(echo "$tag" | cut -c 2-)
+      url="https://github.com/Fireflyest/CraftGUI/releases/download/${tag}/CraftGUI-${version_num}.jar"
+      ;;
+    globalmarket)
+      local tag
+      tag=$(get_latest_tag "https://github.com/Fireflyest/GlobalMarket.git" || echo "1.0.0")
+      local version_num
+      version_num=$(echo "$tag" | cut -c 2-)
+      url="https://github.com/Fireflyest/GlobalMarket/releases/download/${tag}/GlobalMarket-${version_num}.jar"
       ;;
     *)
       print_error "Unknown component: $component"
@@ -185,6 +217,11 @@ update_plugin(){
     vault) jar_name="Vault.jar" ;;
     luckperms) jar_name="LuckPerms.jar" ;;
     griefprevention) jar_name="GriefPrevention.jar" ;;
+    freedomchat) jar_name="FreedomChat.jar" ;;
+    deluxemenus) jar_name="DeluxeMenus.jar" ;;
+    noencryption) jar_name="NoEncryption.jar" ;;
+    craftgui) jar_name="CraftGUI.jar" ;;
+    globalmarket) jar_name="GlobalMarket.jar" ;;
     *) jar_name="${plugin}.jar" ;;
   esac
 
@@ -258,7 +295,8 @@ COMMANDS:
 
     Available Plugins:
         viaversion, viabackwards, multilogin, floodgate, geyser,
-        protocollib, vault, luckperms, griefprevention
+        protocollib, vault, luckperms, griefprevention, freedomchat,
+        deluxemenus, noencryption, craftgui, globalmarket
 
     Info:
         version                     Show version
@@ -279,4 +317,4 @@ NOTES:
 EOF
 }
 
-case "${1:-help}" in build-paper) build_paper "${2:-1.21.1}";; build-spigot) build_spigot "${2:-latest}";; init) init_server;; accept-eula) accept_eula;; update) [[ -z ${2:-} ]] && { print_error "Plugin name required"; printf "Available plugins: viaversion, viabackwards, multilogin, floodgate, geyser, protocollib, vault, luckperms, griefprevention\n"; exit 1; }; update_plugin "$2";; update-all) update_all_plugins;; version) print_header "mcctl version ${MCCTL_VERSION}"; printf "Integrated from: https://github.com/Kraftland/mcctl\n";; help|--help|-h) show_usage;; *) print_error "Unknown command: $1"; show_usage; exit 1;; esac
+case "${1:-help}" in build-paper) build_paper "${2:-1.21.1}";; build-spigot) build_spigot "${2:-latest}";; init) init_server;; accept-eula) accept_eula;; update) [[ -z ${2:-} ]] && { print_error "Plugin name required"; printf "Available plugins: viaversion, viabackwards, multilogin, floodgate, geyser, protocollib, vault, luckperms, griefprevention, freedomchat, deluxemenus, noencryption, craftgui, globalmarket\n"; exit 1; }; update_plugin "$2";; update-all) update_all_plugins;; version) print_header "mcctl version ${MCCTL_VERSION}"; printf "Integrated from: https://github.com/Kraftland/mcctl\n";; help|--help|-h) show_usage;; *) print_error "Unknown command: $1"; show_usage; exit 1;; esac


### PR DESCRIPTION
This commit enhances the existing mcctl integration with features from the upstream Kraftland/mcctl repository (v1.6-stable).

## Changes

### mcctl.sh (v2.0.0 → v2.1.0-integrated)
- Add proper GPL-3.0 license attribution header
- Extend plugin support from 9 to 14 plugins:
  - New: freedomchat, deluxemenus, noencryption, craftgui, globalmarket
  - Existing: viaversion, viabackwards, multilogin, floodgate, geyser, protocollib, vault, luckperms, griefprevention
- Update URL resolution for new plugins with git tag detection
- Maintain modern bash code standards and common.sh integration

### Documentation
- Add CREDITS.md for proper upstream attribution
- Update CLAUDE.md with:
  - Complete list of supported plugins
  - Version information (v2.1.0-integrated based on v1.6-stable)
  - License and authorship details
  - Accept EULA command documentation

### Upstream Integration
- Based on: https://github.com/Kraftland/mcctl
- Original Author: Kimiblock
- Upstream Version: v1.6-stable
- License: GPL-3.0
- Integration maintains repository code standards while preserving core functionality

All changes maintain backward compatibility with existing scripts and follow the repository's code style guidelines.