### PR TITLE
perf: Optimize log reading in monitor.sh and fix CI

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   megalinter:
     name: MegaLinter
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write

--- a/tools/monitor.sh
+++ b/tools/monitor.sh
@@ -61,7 +61,9 @@ get_disk(){
 get_players(){
   print_header "Recent Player Activity"
   # Use tac (reverse) to find last 5 matches efficiently
-  tac "$LOG_FILE" 2>/dev/null | grep -E '(joined|left) the game' -m 5 | tac || printf 'No recent activity\n'
+  local recent_activity
+  recent_activity=$(tail -n 5000 "$LOG_FILE" 2>/dev/null | tac | grep -E '(joined|left) the game' -m 5 | tac || true)
+  [[ -n "$recent_activity" ]] && printf '%s\n' "$recent_activity" || printf 'No recent activity\n'
   printf '\n'
 }
 


### PR DESCRIPTION
Refactored `get_players` in `tools/monitor.sh` to read only the last 5000 lines of the log file using `tail` before processing with `tac`. This avoids reading the entire log file into memory/buffers, which significantly improves performance on large log files.

Also fixed a potential issue where `set -o pipefail` (sourced from `common.sh`) could cause the pipeline to fail or misbehave when the search command exits early or finds no matches. The new implementation captures output safely and handles empty results correctly.

Additionally, updated `.github/workflows/mega-linter.yml` to use `ubuntu-latest` instead of `ubuntu-slim` to fix a CI failure where Docker was unavailable.

## Summary

## Changes
- 

## Testing
- [ ] Not run (explain)
- [ ] Tests run: 

## Checklist
- [ ] Scope is focused and related issues are linked
- [ ] Documentation updated if needed
- [ ] Tests added or updated where applicable
- [ ] No secrets or sensitive data included
