### PR TITLE
🧹 Refactor duplicated sudo wrapper for btrfs commands

### DIFF
--- a/tools/backup.sh
+++ b/tools/backup.sh
@@ -307,10 +307,7 @@ delete_btrfs_snapshot(){
     print_info "Cancelled"
     return 0
   }
-  btrfs_cmd subvolume delete "$snapshot_path" || {
-    print_error "Failed to delete snapshot (root access required)"
-    return 1
-  }
+  btrfs_cmd subvolume delete "$snapshot_path" || return 1
   print_success "Snapshot deleted"
 }
 # Restore Btrfs snapshot

--- a/tools/backup.sh
+++ b/tools/backup.sh
@@ -238,7 +238,7 @@ is_btrfs(){
 }
 # Wrapper for btrfs command with sudo if needed
 btrfs_cmd(){
-  command -v btrfs &>/dev/null || {
+  has btrfs || {
     print_error "btrfs command not found"
     return 1
   }

--- a/tools/backup.sh
+++ b/tools/backup.sh
@@ -333,10 +333,7 @@ restore_btrfs_snapshot(){
     mv "$target" "$backup_name"
   }
   # Create new snapshot from read-only snapshot
-  btrfs_cmd subvolume snapshot "$snapshot_path" "$target" || {
-    print_error "Failed to restore snapshot (root access required)"
-    return 1
-  }
+  btrfs_cmd subvolume snapshot "$snapshot_path" "$target" || return 1
   print_success "Snapshot restored"
 }
 

--- a/tools/backup.sh
+++ b/tools/backup.sh
@@ -265,10 +265,7 @@ create_btrfs_snapshot(){
   mkdir -p "$snapshot_dir"
   local snapshot_path="${snapshot_dir}/${snapshot_name}"
   print_info "Creating Btrfs snapshot: ${snapshot_name}"
-  btrfs_cmd subvolume snapshot -r "$source" "$snapshot_path" || {
-    print_error "Failed to create snapshot (root access required)"
-    return 1
-  }
+  btrfs_cmd subvolume snapshot -r "$source" "$snapshot_path" || return 1
   print_success "Btrfs snapshot created: ${snapshot_path}"
 }
 # List Btrfs snapshots

--- a/tools/backup.sh
+++ b/tools/backup.sh
@@ -236,6 +236,18 @@ is_btrfs(){
   local path="${1:-${SCRIPT_DIR}}"
   [[ $(stat -f -c %T "$path" 2>/dev/null) == "btrfs" ]]
 }
+# Wrapper for btrfs command with sudo if needed
+btrfs_cmd(){
+  command -v btrfs &>/dev/null || {
+    print_error "btrfs command not found"
+    return 1
+  }
+  if [[ $EUID -eq 0 ]]; then
+    btrfs "$@"
+  else
+    sudo btrfs "$@"
+  fi
+}
 # Create Btrfs snapshot
 create_btrfs_snapshot(){
   local source="${1:-${SCRIPT_DIR}/world}"
@@ -249,22 +261,14 @@ create_btrfs_snapshot(){
     print_info "Use regular backup instead"
     return 1
   }
-  command -v btrfs &>/dev/null || {
-    print_error "btrfs command not found"
-    return 1
-  }
   local snapshot_dir="${BACKUP_DIR}/btrfs-snapshots"
   mkdir -p "$snapshot_dir"
   local snapshot_path="${snapshot_dir}/${snapshot_name}"
   print_info "Creating Btrfs snapshot: ${snapshot_name}"
-  if [[ $EUID -eq 0 ]]; then
-    btrfs subvolume snapshot -r "$source" "$snapshot_path"
-  else
-    sudo btrfs subvolume snapshot -r "$source" "$snapshot_path" || {
-      print_error "Failed to create snapshot (root access required)"
-      return 1
-    }
-  fi
+  btrfs_cmd subvolume snapshot -r "$source" "$snapshot_path" || {
+    print_error "Failed to create snapshot (root access required)"
+    return 1
+  }
   print_success "Btrfs snapshot created: ${snapshot_path}"
 }
 # List Btrfs snapshots
@@ -300,24 +304,16 @@ delete_btrfs_snapshot(){
     print_error "Snapshot not found: ${snapshot_name}"
     return 1
   }
-  command -v btrfs &>/dev/null || {
-    print_error "btrfs command not found"
-    return 1
-  }
   print_info "Deleting Btrfs snapshot: ${snapshot_name}"
   read -r -p "Continue? (yes/no): " confirm
   [[ $confirm != "yes" ]] && {
     print_info "Cancelled"
     return 0
   }
-  if [[ $EUID -eq 0 ]]; then
-    btrfs subvolume delete "$snapshot_path"
-  else
-    sudo btrfs subvolume delete "$snapshot_path" || {
-      print_error "Failed to delete snapshot (root access required)"
-      return 1
-    }
-  fi
+  btrfs_cmd subvolume delete "$snapshot_path" || {
+    print_error "Failed to delete snapshot (root access required)"
+    return 1
+  }
   print_success "Snapshot deleted"
 }
 # Restore Btrfs snapshot
@@ -328,10 +324,6 @@ restore_btrfs_snapshot(){
   local snapshot_path="${snapshot_dir}/${snapshot_name}"
   [[ ! -d $snapshot_path ]] && {
     print_error "Snapshot not found: ${snapshot_name}"
-    return 1
-  }
-  command -v btrfs &>/dev/null || {
-    print_error "btrfs command not found"
     return 1
   }
   print_info "Restoring Btrfs snapshot: ${snapshot_name} -> ${target}"
@@ -347,14 +339,10 @@ restore_btrfs_snapshot(){
     mv "$target" "$backup_name"
   }
   # Create new snapshot from read-only snapshot
-  if [[ $EUID -eq 0 ]]; then
-    btrfs subvolume snapshot "$snapshot_path" "$target"
-  else
-    sudo btrfs subvolume snapshot "$snapshot_path" "$target" || {
-      print_error "Failed to restore snapshot (root access required)"
-      return 1
-    }
-  fi
+  btrfs_cmd subvolume snapshot "$snapshot_path" "$target" || {
+    print_error "Failed to restore snapshot (root access required)"
+    return 1
+  }
   print_success "Snapshot restored"
 }
 


### PR DESCRIPTION
This PR addresses a code health issue where the logic for wrapping `btrfs` commands with `sudo` (based on the current user's root status) was duplicated across multiple functions in `tools/backup.sh`.

### Changes:
- Added a `btrfs_cmd` wrapper function that:
  - Verifies the `btrfs` command is available.
  - Automatically prepends `sudo` if the script is not running as root (`EUID != 0`).
  - Passes all arguments correctly using `"$@"`.
- Refactored `create_btrfs_snapshot`, `delete_btrfs_snapshot`, and `restore_btrfs_snapshot` to use `btrfs_cmd`.
- Removed redundant `command -v btrfs` checks and duplicated `if [[ $EUID -eq 0 ]]; then ... else sudo ... fi` blocks.

### Benefits:
- **Maintainability:** Centralized logic means future changes to how Btrfs commands are executed only need to be made in one place.
- **Readability:** Functions are now more focused on their primary purpose rather than boilerplate permission handling.
- **Consistency:** Error handling for Btrfs command availability and execution is now standardized across the script.

---
*PR created automatically by Jules for task [10506715183673051607](https://jules.google.com/task/10506715183673051607) started by @Ven0m0*