### PR TITLE
🧹 Refactor download functions to reduce duplication

### DIFF
--- a/tools/common.sh
+++ b/tools/common.sh
@@ -50,20 +50,31 @@ get_json_processor(){
 # ============================================================================
 # DOWNLOAD FUNCTIONS
 # ============================================================================
-fetch_url(){
-  local url="$1"
-  has curl && { curl -fsSL -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4.212 Safari/537.36" "$url"; return; }
-  has wget && { wget -qO- "$url"; return; }
-  printf 'Error: No download tool found (curl or wget)\n' >&2
-  return 1
-}
-download_file(){
-  local url="$1" output="$2" connections="${3:-8}"
-  has aria2c && { aria2c -x "$connections" -s "$connections" -o "$output" "$url" &>/dev/null; return; }
-  has curl && { curl -fsL -H "Accept-Encoding: identity" -H "Accept-Language: en" -L -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4.212 Safari/537.36" -o "$output" "$url"; return; }
-  has wget && { wget -qO "$output" "$url"; return; }
+DEFAULT_USER_AGENT="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4.212 Safari/537.36"
+
+_do_download(){
+  local url="$1" output="${2:-}" connections="${3:-8}"
+  local headers=(-H "Accept-Encoding: identity" -H "Accept-Language: en" -A "$DEFAULT_USER_AGENT")
+
+  if [[ -n $output ]]; then
+    has aria2c && { aria2c -x "$connections" -s "$connections" -o "$output" "$url" &>/dev/null; return; }
+    has curl && { curl -fsL "${headers[@]}" -L -o "$output" "$url"; return; }
+    has wget && { wget -qO "$output" "$url"; return; }
+  else
+    has curl && { curl -fsSL "${headers[@]}" -L "$url"; return; }
+    has wget && { wget -qO- "$url"; return; }
+  fi
+
   printf 'Error: No download tool found (aria2c, curl, or wget)\n' >&2
   return 1
+}
+
+fetch_url(){
+  _do_download "$1"
+}
+
+download_file(){
+  _do_download "$1" "$2" "${3:-8}"
 }
 verify_checksum(){
   local file="$1" expected_sha256="$2"

--- a/tools/prepare.sh
+++ b/tools/prepare.sh
@@ -99,16 +99,7 @@ download_lazymc(){
   target_file="${INSTALL_DIR}/lazymc"
   expected_checksum=$(get_checksum_for_arch "lazymc" "$arch")
   mkdir -p "$INSTALL_DIR"
-  if has aria2c; then
-    aria2c -x 16 -s 16 -k 1M -d "$INSTALL_DIR" -o lazymc "$url"
-  elif has curl; then
-    curl -fsSL -o "$target_file" "$url"
-  elif has wget; then
-    wget -q -O "$target_file" "$url"
-  else
-    print_error "No download tool found (aria2c, curl, or wget required)"
-    exit 1
-  fi
+  download_file "$url" "$target_file" 16 || exit 1
   verify_checksum "$target_file" "$expected_checksum" || {
     print_error "Checksum verification failed - removing downloaded file"
     rm -f "$target_file"

--- a/tools/world-optimize.sh
+++ b/tools/world-optimize.sh
@@ -32,17 +32,10 @@ WORLD_DIR="${SCRIPT_DIR}/world"
 download_chunk_cleaner(){
   [[ -f $CHUNK_CLEANER_BIN ]] && { print_info "ChunkCleaner already installed"; return 0; }
   print_info "Downloading ChunkCleaner v${CHUNK_CLEANER_VERSION}..."
-  if has curl; then
-    curl -L -o "$CHUNK_CLEANER_BIN" "$CHUNK_CLEANER_URL" || {
-      print_error "Failed to download ChunkCleaner"; return 1
-    }
-  elif has wget; then
-    wget -q --show-progress -O "$CHUNK_CLEANER_BIN" "$CHUNK_CLEANER_URL" || {
-      print_error "Failed to download ChunkCleaner"; return 1
-    }
-  else
-    print_error "Neither wget nor curl found. Please install one of them."; return 1
-  fi
+  download_file "$CHUNK_CLEANER_URL" "$CHUNK_CLEANER_BIN" || {
+    print_error "Failed to download ChunkCleaner"
+    return 1
+  }
   chmod +x "$CHUNK_CLEANER_BIN"
   print_success "ChunkCleaner installed successfully"
 }


### PR DESCRIPTION
This change improves the maintainability of the codebase by centralizing the download logic and tool selection (aria2c, curl, wget) into a single helper function in `tools/common.sh`. It also extracts the common User-Agent string into a shared variable. Scripts that previously implemented their own download tool selection (`prepare.sh` and `world-optimize.sh`) have been updated to use the centralized `download_file` function.

---
*PR created automatically by Jules for task [1340224321757209235](https://jules.google.com/task/1340224321757209235) started by @Ven0m0*