### PR TITLE
🧪 [testing] Add unit tests for RCON hex functions and fix trailing input bug

### DIFF
--- a/tools/rcon.sh
+++ b/tools/rcon.sh
@@ -7,7 +7,7 @@ export LC_ALL=C
 # Given a 4-byte hex string, reverse byte order (little→big endian)
 reverse_hex_endian() {
   local INTEGER
-  while read -r -d '' -N 8 INTEGER; do
+  while read -r -d '' -N 8 INTEGER || [[ -n "$INTEGER" ]]; do
     if [[ "${#INTEGER}" -eq 8 ]]; then
       printf '%s' "${INTEGER:6:2}${INTEGER:4:2}${INTEGER:2:2}${INTEGER:0:2}"
     else
@@ -85,4 +85,6 @@ rcon_command() {
   exec 3>&-
 }
 
-rcon_command "${1:-${RCON_HOST:-localhost}}" "${2:-${RCON_PORT:-25575}}" "${3:-${RCON_PASSWORD:-}}" "$4"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  rcon_command "${1:-${RCON_HOST:-localhost}}" "${2:-${RCON_PORT:-25575}}" "${3:-${RCON_PASSWORD:-}}" "$4"
+fi

--- a/tools/tests/test_rcon.sh
+++ b/tools/tests/test_rcon.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
+# shellcheck enable=all shell=bash source-path=SCRIPTDIR
+set -euo pipefail
+shopt -s nullglob globstar
+export LC_ALL=C
+IFS=$'\n\t'
+
 # Unit tests for tools/rcon.sh
 
+# Source common library
+source "${PWD}/tools/common.sh"
+
 # Source the rcon.sh script
-# Since we wrapped the main execution call, it should only load functions
-source "$(dirname "$0")/../rcon.sh"
+source "${PWD}/tools/rcon.sh"
 
 # Test counter
 tests_run=0

--- a/tools/tests/test_rcon.sh
+++ b/tools/tests/test_rcon.sh
@@ -24,9 +24,9 @@ assert_equals() {
   local description="$3"
   ((tests_run++))
   if [[ "$expected" == "$actual" ]]; then
-    printf "\e[32m[PASS]\e[0m %s\n" "$description"
+    print_success "[PASS] $description"
   else
-    printf "\e[31m[FAIL]\e[0m %s\n" "$description"
+    print_error "[FAIL] $description"
     printf "       Expected: '%s'\n" "$expected"
     printf "       Actual:   '%s'\n" "$actual"
     ((tests_failed++))

--- a/tools/tests/test_rcon.sh
+++ b/tools/tests/test_rcon.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Unit tests for tools/rcon.sh
+
+# Source the rcon.sh script
+# Since we wrapped the main execution call, it should only load functions
+source "$(dirname "$0")/../rcon.sh"
+
+# Test counter
+tests_run=0
+tests_failed=0
+
+# Assertion function
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local description="$3"
+  ((tests_run++))
+  if [[ "$expected" == "$actual" ]]; then
+    printf "\e[32m[PASS]\e[0m %s\n" "$description"
+  else
+    printf "\e[31m[FAIL]\e[0m %s\n" "$description"
+    printf "       Expected: '%s'\n" "$expected"
+    printf "       Actual:   '%s'\n" "$actual"
+    ((tests_failed++))
+  fi
+}
+
+# ----------------------------------------------------------------------------
+# Tests for reverse_hex_endian
+# ----------------------------------------------------------------------------
+printf "Running tests for reverse_hex_endian...\n"
+
+# Standard 8-character hex
+result=$(printf "01020304" | reverse_hex_endian)
+assert_equals "04030201" "$result" "Standard 8-character hex reversal"
+
+# Multiple 8-character blocks
+result=$(printf "1234567801020304" | reverse_hex_endian)
+assert_equals "7856341204030201" "$result" "Multiple 8-character blocks reversal"
+
+# Short input (< 8 chars)
+# Fixed implementation should return short input as-is instead of swallowing it.
+result=$(printf "1234" | reverse_hex_endian)
+assert_equals "1234" "$result" "Short input without 8 characters is returned as-is"
+
+# ----------------------------------------------------------------------------
+# Tests for decode_hex_int
+# ----------------------------------------------------------------------------
+printf "\nRunning tests for decode_hex_int...\n"
+
+result=$(printf "01000000" | decode_hex_int)
+assert_equals "1" "$result" "Decode 01000000 to 1"
+
+result=$(printf "00010000" | decode_hex_int)
+assert_equals "256" "$result" "Decode 00010000 to 256"
+
+# ----------------------------------------------------------------------------
+# Tests for encode_int
+# ----------------------------------------------------------------------------
+printf "\nRunning tests for encode_int...\n"
+
+result=$(encode_int 1)
+assert_equals "01000000" "$result" "Encode 1 to 01000000"
+
+result=$(encode_int 256)
+assert_equals "00010000" "$result" "Encode 256 to 00010000"
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+printf "\nTests completed: %d, Failed: %d\n" "$tests_run" "$tests_failed"
+
+if [[ "$tests_failed" -eq 0 ]]; then
+  exit 0
+else
+  exit 1
+fi

--- a/tools/tests/test_rcon.sh
+++ b/tools/tests/test_rcon.sh
@@ -36,7 +36,7 @@ assert_equals() {
 # ----------------------------------------------------------------------------
 # Tests for reverse_hex_endian
 # ----------------------------------------------------------------------------
-printf "Running tests for reverse_hex_endian...\n"
+print_header "Running tests for reverse_hex_endian"
 
 # Standard 8-character hex
 result=$(printf "01020304" | reverse_hex_endian)


### PR DESCRIPTION
### 🧪 [testing] Add unit tests for RCON hex functions and fix trailing input bug

#### 🎯 What
Addressed the missing test coverage for the core hex manipulation functions in `tools/rcon.sh`. During implementation, a bug was identified where `reverse_hex_endian` would silently swallow any input shorter than 8 characters (or trailing data at the end of a stream); this has been fixed.

#### 📊 Coverage
- **`reverse_hex_endian`**: Now tested with standard 8-char hex, multi-block hex strings, and short inputs (ensuring they are preserved as-is).
- **`decode_hex_int`**: Verified correct decoding of little-endian hex to decimal.
- **`encode_int`**: Verified correct encoding of decimal integers to little-endian hex.

#### ✨ Result
- Improved reliability and maintainability of the pure-Bash RCON client.
- `tools/rcon.sh` is now safely sourceable for testing without executing the command-line interface.
- Bug fix ensures RCON packet processing is more robust against unexpected input lengths.

Tests can be run with: `bash tools/tests/test_rcon.sh`

---
*PR created automatically by Jules for task [15791535305284024798](https://jules.google.com/task/15791535305284024798) started by @Ven0m0*